### PR TITLE
fix: Add nowait option to keymap

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -149,6 +149,7 @@ function View:setup(opts)
       vim.api.nvim_buf_set_keymap(self.buf, "n", key, [[<cmd>lua require("trouble").action("]] .. action .. [[")<cr>]], {
         silent = true,
         noremap = true,
+        nowait = true,
       })
     end
   end


### PR DESCRIPTION
Set keymaps with `nowait` option, this allow users to set single key actions, ex. use `=` to toggle "folds" like the default fugitive mapping