### PR TITLE
fix(lsp): avoid overwriting uri of result

### DIFF
--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -66,8 +66,8 @@ function M.definitions(win, buf, cb, _options)
       return cb({})
     end
     for _, value in ipairs(result) do
-      value.uri = value.targetUri
-      value.range = value.targetSelectionRange
+      value.uri = value.targetUri or value.uri
+      value.range = value.targetSelectionRange or value.range
     end
     local ret = util.locations_to_items({ result }, 0)
     cb(ret)


### PR DESCRIPTION
Small fix to avoid issues with servers that respond with `uri` rather than `targetUri` 