### PR TITLE
Add support for lsp type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A pretty list for showing diagnostics, references, telescope results, quickfix a
   - LSP references
   - LSP implementations
   - LSP definitions
+  - LSP type definitions
   - quickfix list
   - location list
   - [Telescope](https://github.com/nvim-telescope/telescope.nvim) search results
@@ -158,6 +159,7 @@ Modes:
 - **lsp_workspace_diagnostics:** workspace diagnostics from the builtin LSP client
 - **lsp_references:** references of the word under the cursor from the builtin LSP client
 - **lsp_definitions:** definitions of the word under the cursor from the builtin LSP client
+* **lsp_type_definitions:** tupe definitions of the word under the cursor from the builtin LSP client
 - **quickfix:** [quickfix](https://neovim.io/doc/user/quickfix.html) items
 - **loclist:** items from the window's [location list](https://neovim.io/doc/user/quickfix.html)
 

--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -11,6 +11,7 @@ M.providers = {
   lsp_references = lsp.references,
   lsp_implementations = lsp.implementations,
   lsp_definitions = lsp.definitions,
+  lsp_type_definitions = lsp.type_definitions,
   quickfix = qf.qflist,
   loclist = qf.loclist,
   telescope = telescope.telescope,

--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -81,6 +81,27 @@ function M.definitions(win, buf, cb, _options)
   end)
 end
 
+---@return Item[]
+function M.type_definitions(win, buf, cb, _options)
+  local method = "textDocument/typeDefinition"
+  local params = util.make_position_params(win, buf)
+  lsp_buf_request(buf, method, params, function(err, result)
+    if err then
+      util.error("an error happened getting type definitions: " .. err.message)
+      return cb({})
+    end
+    if result == nil or #result == 0 then
+      return cb({})
+    end
+    for _, value in ipairs(result) do
+      value.uri = value.targetUri or value.uri
+      value.range = value.targetSelectionRange or value.range
+    end
+    local ret = util.locations_to_items({ result }, 0)
+    cb(ret)
+  end)
+end
+
 function M.get_signs()
   local signs = {}
   for _, v in pairs(util.severity) do


### PR DESCRIPTION
This PR adds support for the textDocument/typeDefinition feature, allowing you to jump to the definition of the type of a given value
