### PR TITLE
Option to automatically jump when there is only one result (fixes #57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Trouble comes with the following defaults:
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
     auto_fold = false, -- automatically fold a file trouble list at creation
+    auto_jump = false, -- automatically jump if there is only a single result
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Trouble comes with the following defaults:
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
     auto_fold = false, -- automatically fold a file trouble list at creation
-    auto_jump = false, -- automatically jump if there is only a single result
+    auto_jump = {"lsp_definitions"}, -- for the given modes, automatically jump if there is only a single result
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -41,6 +41,7 @@ local defaults = {
   auto_close = false, -- automatically close the list when you have no diagnostics
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
   auto_fold = false, -- automatically fold a file trouble list at creation
+  auto_jump = false, -- automatically jump if there is only a single result
   signs = {
     -- icons / text used for a diagnostic
     error = "",

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -41,7 +41,7 @@ local defaults = {
   auto_close = false, -- automatically close the list when you have no diagnostics
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
   auto_fold = false, -- automatically fold a file trouble list at creation
-  auto_jump = false, -- automatically jump if there is only a single result
+  auto_jump = {"lsp_definitions"}, -- for the given modes, automatically jump if there is only a single result
   signs = {
     -- icons / text used for a diagnostic
     error = "",

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -59,7 +59,7 @@ function Trouble.open(...)
 
   if is_open() then
     Trouble.refresh(opts)
-  elseif not opts.auto and config.options.auto_jump then
+  elseif not opts.auto and vim.tbl_contains(config.options.auto_jump, opts.mode) then
     require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
       if #results == 1 then
         util.jump_to_item(opts.win, opts.precmd, results[1])

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -59,6 +59,14 @@ function Trouble.open(...)
 
   if is_open() then
     Trouble.refresh(opts)
+  elseif not opts.auto and config.options.auto_jump then
+    require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
+      if #results == 1 then
+        util.jump_to_item(opts.win, opts.precmd, results[1])
+      elseif #results > 0 then
+        view = View.create(opts)
+      end
+    end, config.options)
   else
     view = View.create(opts)
   end

--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -2,6 +2,22 @@ local config = require("trouble.config")
 
 local M = {}
 
+function M.jump_to_item(win, precmd, item)
+  -- requiring here, as otherwise we run into a circular dependency
+  local View = require("trouble.view")
+
+  View.switch_to(win)
+  if precmd then
+    vim.cmd(precmd)
+  end
+  if vim.api.nvim_buf_get_option(item.bufnr, "buflisted") == false then
+    vim.cmd("edit #" .. item.bufnr)
+  else
+    vim.cmd("buffer " .. item.bufnr)
+  end
+  vim.api.nvim_win_set_cursor(win, { item.start.line + 1, item.start.character })
+end
+
 function M.count(tab)
   local count = 0
   for _ in pairs(tab) do

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -418,16 +418,7 @@ function View:jump(opts)
     folds.toggle(item.filename)
     self:update()
   else
-    View.switch_to(opts.win or self.parent)
-    if opts.precmd then
-      vim.cmd(opts.precmd)
-    end
-    if vim.api.nvim_buf_get_option(item.bufnr, "buflisted") == false then
-      vim.cmd("edit #" .. item.bufnr)
-    else
-      vim.cmd("buffer " .. item.bufnr)
-    end
-    vim.api.nvim_win_set_cursor(self.parent, { item.start.line + 1, item.start.character })
+    util.jump_to_item(opts.win or self.parent, opts.precmd, item)
   end
 end
 


### PR DESCRIPTION
This PR adds the `auto_jump` option, which allows users to specify a set of modes in which, if there is only a single result, trouble directly jumps to the location rather than opening the list.
