### PR TITLE
Disable 'no results' message when using auto close

### DIFF
--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -35,9 +35,6 @@ function renderer.render(view, opts)
   opts = opts or {}
   local buf = vim.api.nvim_win_get_buf(view.parent)
   providers.get(view.parent, buf, function(items)
-    if #items == 0 then
-      util.warn("no results")
-    end
     local grouped = providers.group(items)
     local count = util.count(grouped)
 
@@ -47,6 +44,10 @@ function renderer.render(view, opts)
         view:close()
         return
       end
+    end
+
+    if #items == 0 then
+      util.warn("no results")
     end
 
     -- Update lsp signs


### PR DESCRIPTION
This might be a potential solution to fix #83.

This prevents the display of the "[Trouble] no results" warning when auto close is enabled.