### PR TITLE
Severity Filtering and Cascading Severity

### DIFF
--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -1,3 +1,5 @@
+local severity = require("trouble.severity")
+
 local M = {}
 
 M.namespace = vim.api.nvim_create_namespace("Trouble")
@@ -79,42 +81,7 @@ M.options = {}
 
 function M.setup(options)
   M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
-  M.fix_severity(M.options)
-end
-
--- this is a bit overboard to validate these settings, but fun
-local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity
-local to_severity = function(severity)
-  if not severity then return nil end
-  return type(severity) == 'string' and DiagnosticSeverity[severity] or severity
-end
-local severity_keys = vim.tbl_keys(DiagnosticSeverity)
-local severity_names = vim.tbl_filter(function(a) return type(a) == "string" end, severity_keys)
-table.sort(severity_names, function (a, b) return to_severity(a) < to_severity(b) end)
-local severity_names_joined = table.concat(severity_names, ", ")
-local severity_expected = "nil, number in range 1..=4, or {"..severity_names_joined .. "}"
-function sev_validate(s)
-  -- Diagnostics
-  return vim.tbl_contains(severity_keys, s)
-end
-function opt_sev_validate(s)
-  if s == nil then return true end
-  if type(s) == 'number' then return s end
-  return sev_validate(s)
-end
-
-function M.fix_severity(opts)
-  vim.validate {
-    min_severity = { opts.min_severity, opt_sev_validate, severity_expected },
-    cascading_severity = { opts.cascading_severity, opt_sev_validate, severity_expected },
-  }
-  -- make them 1..=4 or nil
-  opts.min_severity = to_severity(opts.min_severity)
-  -- min_severity being Hint just runs a no-op filter, so ignore it
-  if opts.min_severity == 4 then
-    opts.min_severity = nil
-  end
-  opts.cascading_severity = to_severity(opts.cascading_severity)
+  severity.fix_config(M.options)
 end
 
 M.setup()

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -37,6 +37,10 @@ local defaults = {
     toggle_fold = { "zA", "za" }, -- toggle fold of current file
     previous = "k", -- preview item
     next = "j", -- next item
+    incr_min_severity = {"+", "="}, -- increase the minimum severity, or enables if disabled
+    decr_min_severity = {"-", "_"}, -- decrease the minimum severity, or disable if below Information
+    incr_cascading_severity = ")", -- increase the cascading severity threshold, enables if disabled
+    decr_cascading_severity = "(", -- decrease the cascading severity threshold, or disables
   },
   indent_lines = true, -- add an indent guide below the fold icons
   auto_open = false, -- automatically open the list when you have diagnostics
@@ -59,6 +63,14 @@ local defaults = {
     "lnum",
     "col",
   },
+  min_severity = nil, -- setting to "Information", "Warning", or "Error" will filter out any less severe LSP diagnostics
+  cascading_severity_threshold = nil, -- with this set, attempts to display one severity of LSP diagnostic at a time.
+                                      -- useful if you want to deal with errors (that stop your code compiling) before
+                                      -- dealing with warnings etc. set to "Hint" to simply enable; set to a higher
+                                      -- severity to display that and all lower severities in one layer.
+                                      -- for example, set to "Information" and once you get rid of errors, and then
+                                      -- get rid of warnings, you are shown info and hints.
+
 }
 
 ---@type TroubleOptions
@@ -67,6 +79,42 @@ M.options = {}
 
 function M.setup(options)
   M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
+  M.fix_severity(M.options)
+end
+
+-- this is a bit overboard to validate these settings, but fun
+local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity
+local to_severity = function(severity)
+  if not severity then return nil end
+  return type(severity) == 'string' and DiagnosticSeverity[severity] or severity
+end
+local severity_keys = vim.tbl_keys(DiagnosticSeverity)
+local severity_names = vim.tbl_filter(function(a) return type(a) == "string" end, severity_keys)
+table.sort(severity_names, function (a, b) return to_severity(a) < to_severity(b) end)
+local severity_names_joined = table.concat(severity_names, ", ")
+local severity_expected = "nil, number in range 1..=4, or {"..severity_names_joined .. "}"
+function sev_validate(s)
+  -- Diagnostics
+  return vim.tbl_contains(severity_keys, s)
+end
+function opt_sev_validate(s)
+  if s == nil then return true end
+  if type(s) == 'number' then return s end
+  return sev_validate(s)
+end
+
+function M.fix_severity(opts)
+  vim.validate {
+    min_severity = { opts.min_severity, opt_sev_validate, severity_expected },
+    cascading_severity = { opts.cascading_severity, opt_sev_validate, severity_expected },
+  }
+  -- make them 1..=4 or nil
+  opts.min_severity = to_severity(opts.min_severity)
+  -- min_severity being Hint just runs a no-op filter, so ignore it
+  if opts.min_severity == 4 then
+    opts.min_severity = nil
+  end
+  opts.cascading_severity = to_severity(opts.cascading_severity)
 end
 
 M.setup()

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -2,6 +2,7 @@ local View = require("trouble.view")
 local config = require("trouble.config")
 local colors = require("trouble.colors")
 local util = require("trouble.util")
+local severity = require("trouble.severity")
 
 colors.setup()
 
@@ -239,6 +240,11 @@ function Trouble.action(action)
   end
   if action == "preview" then
     view:preview()
+  end
+
+  if severity.handles_action(action) then
+    severity.apply_action(action, config)
+    Trouble.refresh()
   end
 
   if Trouble[action] then

--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -3,6 +3,7 @@ local qf = require("trouble.providers.qf")
 local telescope = require("trouble.providers.telescope")
 local lsp = require("trouble.providers.lsp")
 local diagnostic = require("trouble.providers.diagnostic")
+local severity = require("trouble.severity")
 
 local M = {}
 
@@ -53,6 +54,9 @@ function M.get(win, buf, cb, options)
   }, options.sort_keys)
 
   provider(win, buf, function(items)
+    local msg = nil
+    items, msg = severity.filter_severities(options, items)
+    -- sort them by severity and then line number
     table.sort(items, function(a, b)
       for _, key in ipairs(sort_keys) do
         local ak = type(key) == "string" and a[key] or key(a)

--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -66,7 +66,7 @@ function M.get(win, buf, cb, options)
         end
       end
     end)
-    cb(items)
+    cb(items, msg)
   end, options)
 end
 

--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -60,7 +60,7 @@ function renderer.render(view, opts)
     view.items = {}
 
     text:msg(message or "")
-    if config.options.padding then
+    if config.options.padding or message ~= nil then
       text:nl()
     end
 

--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -34,7 +34,7 @@ end
 function renderer.render(view, opts)
   opts = opts or {}
   local buf = vim.api.nvim_win_get_buf(view.parent)
-  providers.get(view.parent, buf, function(items)
+  providers.get(view.parent, buf, function(items, message)
     local auto_jump = vim.tbl_contains(config.options.auto_jump, opts.mode)
     if opts.on_open and #items == 1 and auto_jump and not opts.auto then
       view:close()
@@ -59,6 +59,7 @@ function renderer.render(view, opts)
     local text = Text:new()
     view.items = {}
 
+    text:msg(message or "")
     if config.options.padding then
       text:nl()
     end

--- a/lua/trouble/severity.lua
+++ b/lua/trouble/severity.lua
@@ -112,8 +112,8 @@ function M.apply_action(action, config)
   local key = nil
   if     action == "incr_min_severity"       then fn = incr_sev(1, 3); key = "min_severity"
   elseif action == "decr_min_severity"       then fn = decr_sev(1, 3); key = "min_severity"
-  elseif action == "incr_cascading_severity" then fn = incr_sev(1, 4); key = "cascading_severity_threshold"
-  elseif action == "decr_cascading_severity" then fn = decr_sev(1, 4); key = "cascading_severity_threshold"
+  elseif action == "incr_cascading_severity" then fn = incr_sev(2, 4); key = "cascading_severity_threshold"
+  elseif action == "decr_cascading_severity" then fn = decr_sev(2, 4); key = "cascading_severity_threshold"
   else error("trouble.severity.apply_action called on unknown action '" .. action .. "'") end
   -- print("trouble.severity: applying action " .. action .. " to key " .. key)
   local prev_sev = config.options[key]

--- a/lua/trouble/severity.lua
+++ b/lua/trouble/severity.lua
@@ -33,7 +33,7 @@ end
 function M.fix_config(options)
   vim.validate {
     min_severity = { options.min_severity, opt_sev_validate, severity_expected },
-    cascading_severity = { options.cascading_severity, opt_sev_validate, severity_expected },
+    cascading_severity_threshold = { options.cascading_severity_threshold, opt_sev_validate, severity_expected },
   }
   -- make them 1..=4 or nil
   options.min_severity = to_severity(options.min_severity)
@@ -41,7 +41,11 @@ function M.fix_config(options)
   if options.min_severity == 4 then
     options.min_severity = nil
   end
-  options.cascading_severity = to_severity(options.cascading_severity)
+  options.cascading_severity_threshold = to_severity(options.cascading_severity_threshold)
+  -- cascading_severity_threshold being Error just shows everything, equivalent to no filters at all
+  if options.cascading_severity_threshold == 1 then
+     options.cascading_severity_threshold = nil
+  end
 end
 
 ----------------------------------

--- a/lua/trouble/severity.lua
+++ b/lua/trouble/severity.lua
@@ -200,15 +200,15 @@ function M.filter_severities(options, items)
   local total_hidden = min_hidden + eq_hidden
   local some_hidden = total_hidden .. " diagnostic".. (total_hidden > 1 and "s" or "") .." hidden "
   local min_is = min_sev ~= nil and ("min = "..DiagnosticSeverity[min_sev]) or nil
-  local cas = options.cascading_severity_threshold
-  cas = (cas == 4 and "cascade enabled")
-    or (cas ~= nil and "cascade <= " .. DiagnosticSeverity[cas])
+  local cascade_threshold = options.cascading_severity_threshold
+  cascade_threshold = (cascade_threshold == 4 and "cascade enabled")
+    or (cascade_threshold ~= nil and "cascade <= " .. DiagnosticSeverity[cascade_threshold])
     or nil
   local eq_chosen_is = eq_hidden > 0 and ("only showing "..eq_chosen) or nil
   if total_hidden > 0 then
-    msg = some_hidden .. mk_msg(min_is, cas, nil, nil)
+    msg = some_hidden .. mk_msg(min_is, cascade_threshold, eq_chosen_is)
   else
-    msg = mk_msg(min_is, cas, nil, nil)
+    msg = mk_msg(min_is, cascade_threshold, nil)
   end
   return items, msg
 end

--- a/lua/trouble/severity.lua
+++ b/lua/trouble/severity.lua
@@ -1,0 +1,76 @@
+-- severity filters
+
+local M = {}
+
+-- counter-intuitive. LSP severities are backwards.
+-- nil is least severe (no filter), 4 is next smallest (Hint), 1 is most severe (Error)
+-- however, 4/Hint is meaningless for min_severity.
+-- min and max are not counter intuitive. They represent the min and max of the range of acceptable values.
+function incr_sev(min, max)
+  return function(s)
+    if s == nil then return max
+    elseif s <= min then return min -- can't get more severe than {min}
+    elseif s >= max then return max - 1
+    else return s - 1
+    end
+  end
+end
+
+function decr_sev(min, max)
+  return function(s)
+    if s == nil then return nil -- can't get less severe than nil
+    elseif s >= max then return nil
+    elseif s <= min then return min+1
+    else return s + 1
+    end
+  end
+end
+
+-- not the greatest lua test harness ever, but it works
+-- :lua require'trouble.severity'.__run_tests()
+function M.__run_tests()
+  function testit(start, fn, to_eq)
+    local x = start
+    for i, v in ipairs(to_eq) do
+      x = fn(x)
+      assert((x or "nil") == v, "x ("..(x or "nil")..") should = to_eq["..i.."] = "..(v or "nil").."; "..vim.inspect(to_eq))
+    end
+  end
+
+  testit(nil, incr_sev(1, 3), { 3, 2, 1, 1, 1 })
+  testit(1, decr_sev(1, 3), { 2, 3, "nil", "nil" })
+  testit(nil, incr_sev(1, 4), { 4, 3, 2, 1, 1 })
+  testit(1, decr_sev(1, 4), { 2, 3, 4, "nil", "nil" })
+
+  assert(incr_sev(1, 4)(500) == 3, 'incr on 500 should be 3')
+  assert(incr_sev(1, 4)(0) == 1, 'incr on 0 should be 1')
+  assert(decr_sev(1, 4)(0) == 2, 'decr on zero should be 2')
+  assert(decr_sev(1, 4)(500) == nil, 'decr on 500 should be nil')
+  print("trouble.severity tests passed")
+end
+
+local severity_actions = {
+  "incr_min_severity",
+  "decr_min_severity",
+  "incr_cascading_severity",
+  "decr_cascading_severity",
+}
+
+function M.handles_action(action)
+  return vim.tbl_contains(severity_actions, action)
+end
+
+function M.apply_action(action, config)
+  local fn = nil
+  local key = nil
+  if     action == "incr_min_severity"       then fn = incr_sev(1, 3); key = "min_severity"
+  elseif action == "decr_min_severity"       then fn = decr_sev(1, 3); key = "min_severity"
+  elseif action == "incr_cascading_severity" then fn = incr_sev(1, 4); key = "cascading_severity_threshold"
+  elseif action == "decr_cascading_severity" then fn = decr_sev(1, 4); key = "cascading_severity_threshold"
+  else error("trouble.severity.apply_action called on unknown action '" .. action .. "'") end
+  -- print("trouble.severity: applying action " .. action .. " to key " .. key)
+  local prev_sev = config.options[key]
+  config.options[key] = fn(prev_sev)
+end
+
+return M

--- a/lua/trouble/text.lua
+++ b/lua/trouble/text.lua
@@ -18,6 +18,10 @@ function Text:nl()
   self.lineNr = self.lineNr + 1
 end
 
+function Text:msg(msg)
+    self.current = self.current .. msg
+end
+
 function Text:render(str, group, opts)
   str = str:gsub("[\n]", " ")
   if type(opts) == "string" then


### PR DESCRIPTION
Sometimes working on a big code change, your LSP starts shouting at you. Many of these are often warnings, many more are hints. Often a single error in code will have an error AND a hint attached. I found this got in the way; I love rustc, but hints are best for printed diagnostics and inline suggestions, not a summary of the workspace when you have more important things to do.

I've implemented two things here:

- A severity filter, default keys `+` and `-` to change the minimum severity of diagnostics displayed in the trouble window.
- A cascading severity filter, which will e.g. show errors only until there are no errors, then warnings only until there are no warnings, then info only ... keys `(` and `)` will change at what level this flattens out to show you all remaining diagnostics. So you can have "errors until there are no errors, everything else after that".

I made a little video illustrating these features. (Yes, I originally made this a few months ago. Slipped my mind to PR!)

https://user-images.githubusercontent.com/378760/132983006-6b0255c8-c85f-4157-9fdd-326d4e6d0d87.mov

