### PR TITLE
Update lsp handlers according to the neovim new lsp api

### DIFF
--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -21,7 +21,7 @@ function M.references(win, buf, cb, _options)
   local method = "textDocument/references"
   local params = util.make_position_params(win, buf)
   params.context = { includeDeclaration = true }
-  lsp.buf_request(buf, method, params, function(err, _method, result, _client_id, _bufnr, _config)
+  lsp.buf_request(buf, method, params, function(err, result, _context, _config)
     if err then
       util.error("an error happened getting references: " .. err)
       return cb({})
@@ -39,7 +39,7 @@ function M.implementations(win, buf, cb, _options)
   local method = "textDocument/implementation"
   local params = util.make_position_params(win, buf)
   params.context = { includeDeclaration = true }
-  lsp.buf_request(buf, method, params, function(err, _method, result, _client_id, _bufnr, _config)
+  lsp.buf_request(buf, method, params, function(err, result, _context, _config)
     if err then
       util.error("an error happened getting implementation: " .. err)
       return cb({})
@@ -57,7 +57,7 @@ function M.definitions(win, buf, cb, _options)
   local method = "textDocument/definition"
   local params = util.make_position_params(win, buf)
   params.context = { includeDeclaration = true }
-  lsp.buf_request(buf, method, params, function(err, _method, result, _client_id, _bufnr, _config)
+  lsp.buf_request(buf, method, params, function(err, result, _context, _config)
     if err then
       util.error("an error happened getting definitions: " .. err)
       return cb({})


### PR DESCRIPTION
The plugin does not work with [the neovim new lsp API](https://github.com/neovim/neovim/pull/15504), this pull request fix it.