### PR TITLE
fix: retrieve signs from lsp client

### DIFF
--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -79,7 +79,7 @@ function M.get_signs()
   for _, v in pairs(util.severity) do
     -- pcall to catch entirely unbound or cleared out sign hl group
     local status, sign = pcall(function()
-      return vim.trim(vim.fn.sign_getdefined("LspDiagnosticsSign" .. v)[1].text)
+      return vim.trim(vim.fn.sign_getdefined("DiagnosticSign" .. v)[1].text)
     end)
     if not status then
       sign = v:sub(1, 1)


### PR DESCRIPTION
* Fixes use of `use_lsp_diagnostic_signs`, which was broken by changes introduced in https://github.com/neovim/neovim/pull/15585