### PR TITLE
adding neorg traverse headings provider

### DIFF
--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -2,6 +2,7 @@ local util = require("trouble.util")
 local qf = require("trouble.providers.qf")
 local telescope = require("trouble.providers.telescope")
 local lsp = require("trouble.providers.lsp")
+local neorg = require('trouble.providers.neorg')
 
 local M = {}
 
@@ -14,6 +15,7 @@ M.providers = {
   quickfix = qf.qflist,
   loclist = qf.loclist,
   telescope = telescope.telescope,
+  neorg_traverse_headings = neorg.traverse_headings,
 }
 
 ---@param options TroubleOptions

--- a/lua/trouble/providers/neorg.lua
+++ b/lua/trouble/providers/neorg.lua
@@ -1,0 +1,36 @@
+local util = require("trouble.util")
+
+local M = {}
+
+M.results = {}
+
+
+function M.traverse_headings(win, _buf, cb, _options)
+    M.results = {}
+
+    local lines = vim.api.nvim_buf_get_lines(_buf, 0, -1, true)
+
+    for row, line in ipairs(lines) do
+        local match = line:match("^%s*%*+%s+")
+        if match then
+            local row = row - 1
+            local col = match:len()
+            local pitem = {
+                row = row,
+                col = col,
+                message = line,
+                severity = 0,
+                range = {
+                    start = { line = row, character = col },
+                    ["end"] = { line = row, character = -1 },
+                },
+            }
+            table.insert(M.results, util.process_item(pitem, _buf))
+        end
+    end
+
+    cb(M.results)
+end
+
+
+return M


### PR DESCRIPTION
This adds the ability to traverse headings for the plugin [neorg](https://github.com/nvim-neorg/neorg).
Or maybe it's best if I create a separate plugin because this feature is quite specific to neorg? If so it would be great if trouble.nvim could provide an api that can register external providers. Because currently the ```trouble.providers.init.M``` table is a local variable, and I can't access it from outside.
