### PR TITLE
feat: expand `next`/`previous` API calls; deprecate `skip_groups`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,15 +197,58 @@ vim.api.nvim_set_keymap("n", "gR", "<cmd>Trouble lsp_references<cr>",
 
 ### API
 
-You can use the following functions in your keybindings:
+API functions can be called as `require("trouble").api_function(opts)`. The Trouble window must be opened, but focus is not required. These functions can be used in keybindings.
+
+#### `next` / `previous`
+
+Jump to the next/previous item on the list.
+
+`opts`:
+  - `target`: string list (`"group_any"`, `"group_folded"`, `"group_unfolded"`, `"item_any"`, `"item_error"`, `"item_warning"`, `"item_information"`, `"item_hint"`, `"item_other"`)
+  - `jump`: boolean
+
+Examples:
 
 ```lua
--- jump to the next item, skipping the groups
-require("trouble").next({skip_groups = true, jump = true});
+-- select and jump to the next item, skipping the groups
+require("trouble").next({target = {"item_any"}, jump = true})
 
--- jump to the previous item, skipping the groups
-require("trouble").previous({skip_groups = true, jump = true});
+-- select the next item or a group if it was folded
+require("trouble").next({target = {"item_any", "group_folded"}})
+
+-- select previous "error" item or "warning" item
+require("trouble").previous({target = {"item_error", "item_warning"}})
 ```
+
+Example keybindings:
+
+```vim
+" Vim Script
+" Global
+nnoremap [t <cmd>lua require("trouble").previous({target = {"item_any"}, jump = true})<cr>
+nnoremap ]t <cmd>lua require("trouble").next({target = {"item_any"}, jump = true})<cr>
+" Trouble buffer
+autocmd FileType Trouble nnoremap <buffer> <c-k> <cmd>lua require("trouble").previous({target = {"item_error", "item_warning"}})<cr>
+autocmd FileType Trouble nnoremap <buffer> <c-j> <cmd>lua require("trouble").next({target = {"item_error", "item_warning"}})<cr>
+```
+
+```lua
+-- Lua
+-- Global
+vim.api.nvim_set_keymap("n", "[t", '<cmd>lua require("trouble").previous({target = {"item_any"}, jump = true})<cr>',
+  {silent = true, noremap = true}
+)
+vim.api.nvim_set_keymap("n", "]t", '<cmd>lua require("trouble").next({target = {"item_any"}, jump = true})<cr>',
+  {silent = true, noremap = true}
+)
+-- Trouble buffer
+vim.api.nvim_command([[
+autocmd FileType Trouble nnoremap <buffer> <c-k> <cmd>lua require("trouble").previous({target = {"item_error", "item_warning"}})<cr>
+autocmd FileType Trouble nnoremap <buffer> <c-j> <cmd>lua require("trouble").next({target = {"item_error", "item_warning"}})<cr>
+]])
+```
+
+Make sure they don't clash with Trouble's `action_keys` keybindings.
 
 ### Telescope
 

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -374,29 +374,55 @@ function View:current_item()
 end
 
 function View:next_item(opts)
-  opts = opts or { skip_groups = false }
+  opts = opts or { target = { "group_any", "item_any" } }
+  -- deprecated
+  if opts.skip_groups then
+    opts.target = { "item_any" }
+  end
+
   local line = self:get_line()
   for i = line + 1, vim.api.nvim_buf_line_count(self.buf), 1 do
-    if self.items[i] and not (opts.skip_groups and self.items[i].is_file) then
-      vim.api.nvim_win_set_cursor(self.win, { i, self:get_col() })
-      if opts.jump then
-        self:jump()
+    local item = self.items[i]
+    if item then
+      if item.is_file and (vim.tbl_contains(opts.target, "group_any") or
+        vim.tbl_contains(opts.target, "group_folded") and folds.is_folded(item.filename) or
+        vim.tbl_contains(opts.target, "group_unfolded") and not folds.is_folded(item.filename)) or
+        not item.is_file and (vim.tbl_contains(opts.target, "item_any") or
+        vim.tbl_contains(opts.target, "item_" .. string.lower(util.severity[item.severity])))
+      then
+        vim.api.nvim_win_set_cursor(self.win, { i, self:get_col() })
+        if opts.jump then
+          self:jump()
+        end
+        return
       end
-      return
     end
   end
 end
 
 function View:previous_item(opts)
-  opts = opts or { skip_groups = false }
+  opts = opts or { target = { "group_any", "item_any" } }
+  -- deprecated
+  if opts.skip_groups then
+    opts.target = { "item_any" }
+  end
+
   local line = self:get_line()
   for i = line - 1, 0, -1 do
-    if self.items[i] and not (opts.skip_groups and self.items[i].is_file) then
-      vim.api.nvim_win_set_cursor(self.win, { i, self:get_col() })
-      if opts.jump then
-        self:jump()
+    local item = self.items[i]
+    if item then
+      if item.is_file and (vim.tbl_contains(opts.target, "group_any") or
+        vim.tbl_contains(opts.target, "group_folded") and folds.is_folded(item.filename) or
+        vim.tbl_contains(opts.target, "group_unfolded") and not folds.is_folded(item.filename)) or
+        not item.is_file and (vim.tbl_contains(opts.target, "item_any") or
+        vim.tbl_contains(opts.target, "item_" .. string.lower(util.severity[item.severity])))
+      then
+        vim.api.nvim_win_set_cursor(self.win, { i, self:get_col() })
+        if opts.jump then
+          self:jump()
+        end
+        return
       end
-      return
     end
   end
 end


### PR DESCRIPTION
Allow fine-tuning said API calls to be able to pick the exact type of items to select next. For example:


```lua
-- Selecting any item or folded group
require("trouble").next({target = {"item_any", "group_folded"}})
```

```lua
-- Selecting only 'error' and 'warning' items
require("trouble").previous({target = {"item_error", "item_warning"}})
```

Possible target items: `"group_any"`, `"group_folded"`, `"group_unfolded"`, `"item_any"`, `"item_error"`, `"item_warning"`, `"item_information"`, `"item_hint"`, `"item_other"`

This list can easily be expanded in the future.

---

`View:next_item` and `View:previous_item` are practically the same, except iteration direction, so maybe it makes sense to abstract them to 1 private method. But I'm not sure about the project's coding conventions, so I'll leave it as it is.

---
Closes #63