### PR TITLE
fix: prevent shuffling Telescope provider results on Trouble view refresh

### DIFF
--- a/lua/trouble/providers/telescope.lua
+++ b/lua/trouble/providers/telescope.lua
@@ -74,7 +74,7 @@ function M.telescope(_win, _buf, cb, _options)
   if #M.results == 0 then
     util.warn("No Telescope results found. Open Telescopen and send results to Trouble first. Refer to the documentation for more info.")
   end
-  cb(M.results)
+  cb(vim.deepcopy(M.results))
 end
 
 return M


### PR DESCRIPTION
An example of looking up word `local` inside Trouble project and continuously closing all folds:

https://user-images.githubusercontent.com/85341530/141748044-12be04d5-7515-4341-b229-0f397a142b35.mp4


The bug is caused by [`table.sort`](https://github.com/folke/trouble.nvim/blob/756f09de113a775ab16ba6d26c090616b40a999d/lua/trouble/providers/init.lua#L38-L44) being applied to Telescope results over and over again. Since `table.sort` order for equal items is non-deterministic, the items with equal parameters (`item.severity`, `item.lnum`) get shuffled around every time `table.sort` is called.

The fix is to copy the original results table and pass it to sorting function every time sorting is done.

---

This fix is a band-aid that barely covers the actual problem, which lies in Trouble's architecture. There are currently 2 issues:

1. Every time Trouble view gets refreshed, it polls current provider for new information and sorts items globally. If the provider's output on the next poll is the exact same, everything's fine. But if it removes/adds an item matching priority+position of another item, this can drastically change Trouble layout due to `table.sort`'s non-deterministic behaviour. The more items Trouble works with, the worse it gets.
2. Grouped items are [put in a dictionary](https://github.com/folke/trouble.nvim/blob/756f09de113a775ab16ba6d26c090616b40a999d/lua/trouble/providers/init.lua#L55) instead of a list, so the correct [iteration order](https://github.com/folke/trouble.nvim/blob/d40695ee07736d16bd764afb48faa193a33641ac/lua/trouble/renderer.lua#L64) is not guaranteed.

### Some thoughts

The good architecture for fetching items would be:
  1. Poll providers asynchronously in the background (on timer / provider events / etc.)
  2. Group items by filename in a list in the exact order provider passed it to Trouble. This ensures consistent order of grouped items.
  3. Sort items on per-file basis. Item severity+position clashing is very unlikely there and if it happens, it won't affect much. *There is much room for optimization, maybe just save correct file order in `#2`, then perform global sorting and then group the results.* 
  4. Cache the sorted list and work with it, when updating the view.

The fetching would become more resource-demanding, but making it async+cached will negate this drawback as well as provide many benefits. For example:
- Fetching results will become a non-blocking operation done in the background. Currently, getting 10k+ results freezes Neovim for a significant amount of time (#112).
- Obviously, consistent results order.
- Caching will make local operations, like folding, instantaneous. This will also allow for implementing features, that would be too costly otherwise, like updating Trouble's cursor in real time in sync with the buffer you're working with (#32).

Things that should probably be considered: #33 #65

I'm not up for this task, though. Just throwing ideas around.