### PR TITLE
Set `icons = false` in icon-less setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Modes:
 Example keybindings:
 
 ```vim
--- Vim Script
+" Vim Script
 nnoremap <leader>xx <cmd>TroubleToggle<cr>
 nnoremap <leader>xw <cmd>TroubleToggle lsp_workspace_diagnostics<cr>
 nnoremap <leader>xd <cmd>TroubleToggle lsp_document_diagnostics<cr>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Trouble comes with the following defaults:
 ```lua
 -- settings without a patched font or icons
 {
+    icons = false,
     fold_open = "v", -- icon used for open folds
     fold_closed = ">", -- icon used for closed folds
     indent_lines = false, -- add an indent guide below the fold icons


### PR DESCRIPTION
Configuration fails for an icon-less setup with the given example if `icons = false` is not explicitly set.
![2021-12-06-212259_950x87_scrot](https://user-images.githubusercontent.com/45740526/144971659-f31994ce-8ee3-4932-9477-d96b293ae95e.png)

