### PR TITLE
README: fix: instead of `use_lsp_diagnostic_signs` use `use_diagnosti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Trouble comes with the following defaults:
         information = "",
         other = "﫠"
     },
-    use_lsp_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
+    use_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
 }
 ```
 


### PR DESCRIPTION
`use_lsp_diagnostic_signs` is no longer being used, but README still has it.