### PR TITLE
feat: Track the cursor in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Trouble comes with the following defaults:
       other = "",
     },
     use_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
+    track_cursor = false, -- automatically track the cursor and update the selected item
 }
 ```
 

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -68,6 +68,7 @@ local defaults = {
     "lnum",
     "col",
   },
+  track_cursor = false, -- automatically track the cursor and update the selected item
 }
 
 ---@type TroubleOptions

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -297,4 +297,10 @@ function Trouble.get_items()
   end
 end
 
+function Trouble.update_selected_item()
+  if view then
+    view:update_selected_item()
+  end
+end
+
 return Trouble

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -127,6 +127,9 @@ end
 function View:update(opts)
   util.debug("update")
   renderer.render(self, opts)
+  if config.options.track_cursor then
+    self:update_selected_item()
+  end
 end
 
 function View:setup(opts)
@@ -193,6 +196,18 @@ function View:setup(opts)
     ]],
     false
   )
+
+  if config.options.track_cursor then
+      vim.api.nvim_exec(
+        [[
+          augroup TroubleTrackCursor
+            autocmd!
+            autocmd CursorMoved * lua require("trouble").update_selected_item()
+          augroup END
+        ]],
+        false
+      )
+  end
 
   if not opts.parent then
     self:on_enter()
@@ -386,6 +401,35 @@ function View:get_line()
 end
 function View:get_col()
   return self:get_cursor()[2]
+end
+
+function View:update_selected_item()
+  if vim.api.nvim_get_current_win() ~= self.parent then
+    return
+  end
+
+  -- This is the buf and the current location of the cursor
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cursor = vim.api.nvim_win_get_cursor(self.parent)
+  local row = cursor[1]
+  local col = cursor[2] + 1
+
+  local found = nil
+  for i, item in ipairs(self.items) do
+    if item.bufnr == bufnr and item.lnum == row then
+      -- If there are two items at the same line, go to the one closer to the cursor
+      if found == nil or (col >= item.col and found.item.col < item.col) then
+        found = {
+          row = i,
+          item = item,
+        }
+      end
+    end
+  end
+
+  if found then
+    vim.api.nvim_win_set_cursor(self.win, { found.row, self:get_col() })
+  end
 end
 
 function View:current_item()

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -408,6 +408,11 @@ function View:update_selected_item()
     return
   end
 
+  -- FIXME: Why is self.win not valid sometimes?
+  if not vim.api.nvim_win_is_valid(self.win) then
+    return
+  end
+
   -- This is the buf and the current location of the cursor
   local bufnr = vim.api.nvim_get_current_buf()
   local cursor = vim.api.nvim_win_get_cursor(self.parent)


### PR DESCRIPTION
Track the cursor inside the list, keeping it in sync with what is happening at the main window.

I did leave it set to `false` by default, but I can change it to `true` if desired.

ps. Don't know if `track_cursor` is the best option name for it.

Fix #32 