### PR TITLE
Update lua examples to use new mapping functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,24 +180,12 @@ nnoremap gR <cmd>TroubleToggle lsp_references<cr>
 
 ```lua
 -- Lua
-vim.api.nvim_set_keymap("n", "<leader>xx", "<cmd>Trouble<cr>",
-  {silent = true, noremap = true}
-)
-vim.api.nvim_set_keymap("n", "<leader>xw", "<cmd>Trouble workspace_diagnostics<cr>",
-  {silent = true, noremap = true}
-)
-vim.api.nvim_set_keymap("n", "<leader>xd", "<cmd>Trouble document_diagnostics<cr>",
-  {silent = true, noremap = true}
-)
-vim.api.nvim_set_keymap("n", "<leader>xl", "<cmd>Trouble loclist<cr>",
-  {silent = true, noremap = true}
-)
-vim.api.nvim_set_keymap("n", "<leader>xq", "<cmd>Trouble quickfix<cr>",
-  {silent = true, noremap = true}
-)
-vim.api.nvim_set_keymap("n", "gR", "<cmd>Trouble lsp_references<cr>",
-  {silent = true, noremap = true}
-)
+vim.keymap.set("n", "<leader>xx", function() require("trouble").open() end())
+vim.keymap.set("n", "<leader>xw", function() require("trouble").open("workspace_diagnostics") end())
+vim.keymap.set("n", "<leader>xd", function() require("trouble").open("document_diagnostics") end())
+vim.keymap.set("n", "<leader>xl", function() require("trouble").open("quickfix") end())
+vim.keymap.set("n", "<leader>xq", function() require("trouble").open("loclist") end())
+vim.keymap.set("n", "gR", function() require("trouble").open("lsp_references") end())
 ```
 
 ### API


### PR DESCRIPTION
This updates the examples to use the new lua mapping functions in neovim 0.7.

`remap = false` is the default, so no need to specify `noremap = true`. `silent` has no effect here.