### PR TITLE
fix: set win number to 0 when win is nil

### DIFF
--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -63,6 +63,9 @@ function Trouble.open(...)
   elseif not opts.auto and vim.tbl_contains(config.options.auto_jump, opts.mode) then
     require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
       if #results == 1 then
+        if opts.win == nil then
+          opts.win = 0
+        end
         util.jump_to_item(opts.win, opts.precmd, results[1])
       elseif #results > 0 then
         view = View.create(opts)


### PR DESCRIPTION
#153 #161 
This commit manually set the win number to 0 if it's nil.
It works for me with no error. Someone said that it will fail if trying to jump another file, but I can't reproduce this bug.
Does anyone can provide an example to reproduce the problem of this commit so that I can try to fix it.