### PR TITLE
Make sorting keys configurable

### DIFF
--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -53,6 +53,12 @@ local defaults = {
     other = "﫠",
   },
   use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
+  sort_keys = {
+    "severity",
+    "filename",
+    "lnum",
+    "col",
+  },
 }
 
 ---@type TroubleOptions

--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -36,7 +36,7 @@ function M.get(win, buf, cb, options)
     return {}
   end
 
-  local sort_keys = {
+  local sort_keys = vim.list_extend({
     function(item)
       local cwd = vim.loop.fs_realpath(vim.fn.getcwd())
       local path = vim.loop.fs_realpath(item.filename)
@@ -50,11 +50,7 @@ function M.get(win, buf, cb, options)
       end
       return ret
     end,
-    "severity",
-    "filename",
-    "lnum",
-    "col",
-  }
+  }, options.sort_keys)
 
   provider(win, buf, function(items)
     table.sort(items, function(a, b)


### PR DESCRIPTION
For example, to sort entries by line number, use:

```lua
require("trouble").setup({
  sort_keys = {
    "filename",
    "lnum",
    "col",
    "severity",
  }
})
```


The defaults remain the same.

Fixes: https://github.com/folke/trouble.nvim/issues/65