### PR TITLE
fix: loclist opens as qf window (#73)

### DIFF
--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -53,9 +53,6 @@ end
 
 function Trouble.open(...)
   local opts = get_opts(...)
-  if opts.mode and (opts.mode ~= config.options.mode) then
-    config.options.mode = opts.mode
-  end
   opts.focus = true
 
   if is_open() then

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -346,8 +346,10 @@ function View.create(opts)
     vim.cmd("enew")
   else
     vim.cmd("below new")
-    local pos = { bottom = "J", top = "K", left = "H", right = "L" }
-    vim.cmd("wincmd " .. (pos[config.options.position] or "K"))
+    if opts.mode ~= "loclist" and config.options.mode ~= "loclist" then
+      local pos = { bottom = "J", top = "K", left = "H", right = "L" }
+      vim.cmd("wincmd " .. (pos[config.options.position] or "K"))
+    end
   end
   local buffer = View:new(opts)
   buffer:setup(opts)


### PR DESCRIPTION
Currently, opening the trouble loclist ignores split boundaries. The loclist is usually a window local list "inside" the current windows split. There is no further description in #73, but I guess that's the problem the opener of that issue is also facing.

Considering different variables I have the guess, that the mechanic might be more complicated here. Depending on the preferences of how this feature should work it might be required to add further conditions. I'm open to convert this PR to a Draft and listen for further suggestions.