### PR TITLE
feat: add non current highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The table below shows all the highlight groups defined for Trouble.
 | _TroubleCount_           |
 | _TroubleError_           |
 | _TroubleNormal_          |
+| _TroubleNormalNC_        |
 | _TroubleTextInformation_ |
 | _TroubleSignWarning_     |
 | _TroubleLocation_        |

--- a/doc/trouble.nvim.txt
+++ b/doc/trouble.nvim.txt
@@ -1,4 +1,4 @@
-*trouble.nvim.txt*        For Neovim >= 0.8.0        Last change: 2023 July 29
+*trouble.nvim.txt*       For Neovim >= 0.8.0       Last change: 2023 August 04
 
 ==============================================================================
 Table of Contents                             *trouble.nvim-table-of-contents*

--- a/lua/trouble/colors.lua
+++ b/lua/trouble/colors.lua
@@ -14,6 +14,7 @@ local links = {
   Location = "LineNr",
   FoldIcon = "CursorLineNr",
   Normal = "Normal",
+  NormalNC = "NormalNC",
   Count = "TabLineSel",
   Preview = "Search",
   Indent = "LineNr",

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -5,6 +5,8 @@ local util = require("trouble.util")
 
 local highlight = vim.api.nvim_buf_add_highlight
 
+local winhl = "Normal:TroubleNormal,NormalNC:TroubleNormalNC,EndOfBuffer:TroubleNormal,SignColumn:TroubleNormal"
+
 ---@class TroubleView
 ---@field buf number
 ---@field win number
@@ -152,7 +154,7 @@ function View:setup(opts)
   self:set_option("foldcolumn", "0", true)
   self:set_option("foldlevel", 3, true)
   self:set_option("foldenable", false, true)
-  self:set_option("winhighlight", "Normal:TroubleNormal,EndOfBuffer:TroubleNormal,SignColumn:TroubleNormal", true)
+  self:set_option("winhighlight", winhl, true)
   self:set_option("fcs", "eob: ", true)
 
   for action, keys in pairs(config.options.action_keys) do
@@ -306,7 +308,7 @@ function View:on_win_enter()
     -- open the buffer in the parent
     vim.api.nvim_win_set_buf(parent, current_buf)
     -- HACK: some window local settings need to be reset
-    vim.api.nvim_win_set_option(parent, "winhl", "")
+    vim.api.nvim_win_set_option(parent, "winhl", winhl)
     -- close the current trouble window
     vim.api.nvim_win_close(self.win, false)
     -- open a new trouble window


### PR DESCRIPTION
Allows colorschemes to set different background color for non current window without having to duplicate all the highlight groups for current and non current windows.
Also set winhl to the same value in on_win_enter as in setup so that the NormalNC highlight group takes effect from the start. Otherwise the window stays "Normal" until lines get rendered.