### PR TITLE
Fix 'Cursor position outside buffer' error on empty buffer

### DIFF
--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -15,7 +15,8 @@ function M.jump_to_item(win, precmd, item)
   else
     vim.cmd("buffer " .. item.bufnr)
   end
-  vim.api.nvim_win_set_cursor(win or 0, { (item.start.line == 1 and item.start.line or item.start.line + 1), item.start.character })
+  local line = ((item.start.line == 1 or item.start.line == vim.api.nvim_buf_line_count(item.bufnr)) and item.start.line or item.start.line + 1)
+  vim.api.nvim_win_set_cursor(win or 0, { line, item.start.character })
 end
 
 function M.fix_mode(opts)

--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -15,7 +15,7 @@ function M.jump_to_item(win, precmd, item)
   else
     vim.cmd("buffer " .. item.bufnr)
   end
-  vim.api.nvim_win_set_cursor(win or 0, { item.start.line + 1, item.start.character })
+  vim.api.nvim_win_set_cursor(win or 0, { (item.start.line == 1 and item.start.line or item.start.line + 1), item.start.character })
 end
 
 function M.fix_mode(opts)

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -450,7 +450,8 @@ function View:_preview()
 
   if item.is_file ~= true then
     vim.api.nvim_win_set_buf(self.parent, item.bufnr)
-    vim.api.nvim_win_set_cursor(self.parent, { (item.start.line == 1 and item.start.line or item.start.line + 1), item.start.character })
+    local line = ((item.start.line == 1 or item.start.line == vim.api.nvim_buf_line_count(item.bufnr)) and item.start.line or item.start.line + 1)
+    vim.api.nvim_win_set_cursor(self.parent, { line, item.start.character })
 
     vim.api.nvim_buf_call(item.bufnr, function()
       -- Center preview line on screen and open enough folds to show it

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -450,7 +450,7 @@ function View:_preview()
 
   if item.is_file ~= true then
     vim.api.nvim_win_set_buf(self.parent, item.bufnr)
-    vim.api.nvim_win_set_cursor(self.parent, { item.start.line + 1, item.start.character })
+    vim.api.nvim_win_set_cursor(self.parent, { (item.start.line == 1 and item.start.line or item.start.line + 1), item.start.character })
 
     vim.api.nvim_buf_call(item.bufnr, function()
       -- Center preview line on screen and open enough folds to show it


### PR DESCRIPTION
This pull request fixes a "Cursor position outside buffer" error when attempting to preview, or jump to diagnostics in empty buffers. ISO C demands that each translation unit (source file, buffer) comprising a program must include at least one declaration. Empty translation units do not contain any declarations, thereby violating the standard. clangd correctly issues a warning for empty translation units, and attempting to preview, or jump to such a warning causes the error.