### PR TITLE
Enable looping during next/prev / expose is_open

### DIFF
--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -44,6 +44,7 @@ local defaults = {
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
   auto_fold = false, -- automatically fold a file trouble list at creation
   auto_jump = { "lsp_definitions" }, -- for the given modes, automatically jump if there is only a single result
+  loop = true, -- loop cursor on next/prev actions that would otherwise be out-of-bounds
   signs = {
     -- icons / text used for a diagnostic
     error = "",

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -9,8 +9,8 @@ local Trouble = {}
 
 local view
 
-local function is_open()
-  return view and view:is_valid()
+function Trouble.is_open()
+  return view and view:is_valid() or false
 end
 
 function Trouble.setup(options)
@@ -20,7 +20,7 @@ function Trouble.setup(options)
 end
 
 function Trouble.close()
-  if is_open() then
+  if Trouble.is_open() then
     view:close()
   end
 end
@@ -58,7 +58,7 @@ function Trouble.open(...)
   end
   opts.focus = true
 
-  if is_open() then
+  if Trouble.is_open() then
     Trouble.refresh(opts)
   elseif not opts.auto and vim.tbl_contains(config.options.auto_jump, opts.mode) then
     require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
@@ -82,7 +82,7 @@ function Trouble.toggle(...)
     return
   end
 
-  if is_open() then
+  if Trouble.is_open() then
     Trouble.close()
   else
     Trouble.open(...)
@@ -110,7 +110,7 @@ end
 
 local updater = util.debounce(100, function()
   -- buff might have been closed during the debounce
-  if not is_open() then
+  if not Trouble.is_open() then
     util.debug("refresh: not open anymore")
     return
   end
@@ -138,7 +138,7 @@ function Trouble.refresh(opts)
     end
   end
 
-  if is_open() then
+  if Trouble.is_open() then
     if opts.auto then
       updater()
     else
@@ -167,7 +167,7 @@ function Trouble.action(action)
   if view and action == "on_win_enter" then
     view:on_win_enter()
   end
-  if not is_open() then
+  if not Trouble.is_open() then
     return Trouble
   end
   if action == "hover" then


### PR DESCRIPTION
This PR accomplishes two goals:

1. It enables users to loop through results in the Trouble buffer. The `previous` action on the first result will loop you to the last result, whereas the `next` action on the last result will loop you to the first results.


https://user-images.githubusercontent.com/21346716/202375562-7270eb48-8c7a-4233-b04a-7810e74b2870.mov



2. Exposes the `is_open` method. Useful when creating trouble-aware mappings. For example, I want to be able to just press `<C-j>` and have that open trouble for me if it's not open, and if it is take me to the next result

```
km.nnoremap('<C-j>', function()
  if not trouble.is_open() then
    trouble.open()
  else
    trouble.next({ skip_groups = true, jump = true })
  end
end)
km.nnoremap('<C-k>', function()
  if not trouble.is_open() then
    trouble.open()
  else
    trouble.previous({ skip_groups = true, jump = true })
  end
end)
```