### PR TITLE
fix: ensure first line is selected when padding is false

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -312,7 +312,9 @@ function View:focus()
   local line = self:get_line()
   if line == 1 then
     self:next_item()
-    self:next_item()
+    if config.options.padding then
+      self:next_item()
+    end
   end
 end
 


### PR DESCRIPTION
I noticed that when I had padding set to `false` I was being dropped on the wrong line. This fix makes sure that we only move down two lines if padding is set to `true`.