### PR TITLE
Focus parent before closing

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -335,6 +335,7 @@ end
 function View:close()
   util.debug("close")
   if vim.api.nvim_win_is_valid(self.win) then
+    vim.api.nvim_set_current_win(self.parent)
     vim.api.nvim_win_close(self.win, {})
   end
   if vim.api.nvim_buf_is_valid(self.buf) then


### PR DESCRIPTION
I believe this should fix #240, #59, and #209, and #189. It simply focuses `self.parent` before calling `nvim_win_close()` in the `View:close()` function. As far as I can tell, this function is only called when the Trouble window/list is closed (with `q` or `:TroubleToggle` or `:TroubleClose`).

I think this should be less likely to cause issues than the change in https://github.com/folke/trouble.nvim/pull/72 that was reverted. That change modified `View:close_preview()`, which is called every time the [`BufLeave` autocmd](https://github.com/folke/trouble.nvim/blob/main/lua/trouble/view.lua#L181) is triggered, which (in addition to when closing the Trouble window) happens every time you select a diagnostic item in the Trouble window with `Return`.