### PR TITLE
feat(diagnostic): pass opts to `diagnostic.get()`

### DIFF
--- a/lua/trouble/providers/diagnostic.lua
+++ b/lua/trouble/providers/diagnostic.lua
@@ -13,7 +13,7 @@ function M.diagnostics(_, buf, cb, options)
   local items = {}
 
   if vim.diagnostic then
-    local diags = vim.diagnostic.get(buf)
+    local diags = vim.diagnostic.get(buf, options.cmd_options)
     for _, item in ipairs(diags) do
       table.insert(items, util.process_item(item))
     end


### PR DESCRIPTION
Passes `cmd_options` to `vim.diagnostic.get()`, this makes it possible to use `severity` to filter diagnostics.