### PR TITLE
fix: avoid removing newlines in util.lua

### DIFF
--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -166,7 +166,7 @@ function M.process_item(item, bufnr)
     sign = item.sign,
     sign_hl = item.sign_hl,
     -- remove line break to avoid display issues
-    text = vim.trim(item.message:gsub("[\n]", "")):sub(0, vim.o.columns),
+    text = vim.trim(item.message):sub(0, vim.o.columns),
     full_text = vim.trim(item.message),
     type = M.severity[item.severity] or M.severity[0],
     code = item.code or (item.user_data and item.user_data.lsp and item.user_data.lsp.code),


### PR DESCRIPTION
From what I can tell, the new lines are already handled by line 20 of text.lua. By removing the code in util.lua, the code in text.lua can be used so that we have a space replacing the newline instead of nothing.