### PR TITLE
fix: set window options locally

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -78,9 +78,9 @@ end
 
 function View:set_option(name, value, win)
   if win then
-    return vim.api.nvim_win_set_option(self.win, name, value)
+    return vim.api.nvim_set_option_value(name, value, { win = self.win, scope = 'local' })
   else
-    return vim.api.nvim_buf_set_option(self.buf, name, value)
+    return vim.api.nvim_set_option_value(name, value, { buf = self.buf })
   end
 end
 


### PR DESCRIPTION
`:Trouble lsp_definitions` can sometimes leak window options to new windows.