### PR TITLE
read item contents by `bufnr` instead of reading file by path

### DIFF
--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -147,12 +147,11 @@ function M.process_item(item, bufnr)
   local col = start.character
 
   if not item.message and filename then
-    local fd = assert(uv.fs_open(filename, "r", 438))
-    local stat = assert(uv.fs_fstat(fd))
-    local data = assert(uv.fs_read(fd, stat.size, 0))
-    assert(uv.fs_close(fd))
-
-    item.message = vim.split(data, "\n", { plain = true })[row + 1] or ""
+    if not vim.api.nvim_buf_is_loaded(bufnr) then
+      vim.fn.bufload(bufnr)
+    end
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)[row+1]
+    item.message = lines or ""
   end
 
   ---@class Item

--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -150,8 +150,8 @@ function M.process_item(item, bufnr)
     if not vim.api.nvim_buf_is_loaded(bufnr) then
       vim.fn.bufload(bufnr)
     end
-    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)[row+1]
-    item.message = lines or ""
+    local lines = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)
+    item.message = lines[1] or ""
   end
 
   ---@class Item


### PR DESCRIPTION
```lua
  local fd = assert(uv.fs_open(filename, "r", 438))
```

the `filename` might not be an valid file path, for example, the jdtls could return something like this `jdt://contents/commons-collections4-4.4.jar/org.apache.commons.collections4.list/AbstractLinkedList.class?=b`

it causes an error

```
stack traceback:
        [C]: in function 'assert'
        ....local/share/nvim/lazy/trouble.nvim/lua/trouble/util.lua:150: in function 'process_item'
        ....local/share/nvim/lazy/trouble.nvim/lua/trouble/util.lua:193: in function 'locations_to_items'
        ...are/nvim/lazy/trouble.nvim/lua/trouble/providers/lsp.lua:44: in function 'handler'
        ...are/nvim/lazy/trouble.nvim/lua/trouble/providers/lsp.lua:9: in function 'handler'
        ...w/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp.lua:1394: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>

``` 