### PR TITLE
Check parent window is valid before setting active

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -335,7 +335,9 @@ end
 function View:close()
   util.debug("close")
   if vim.api.nvim_win_is_valid(self.win) then
-    vim.api.nvim_set_current_win(self.parent)
+    if vim.api.nvim_win_is_valid(self.parent) then
+      vim.api.nvim_set_current_win(self.parent)
+    end
     vim.api.nvim_win_close(self.win, {})
   end
   if vim.api.nvim_buf_is_valid(self.buf) then


### PR DESCRIPTION
When exiting neovim with only one window open (besides trouble), there's no parent window to set active. This verifies that the parent window is valid before setting it active.

With this in place, neovim exits cleanly when trouble is the last window open. If there is another window, that window becomes active and neovim does not exit.

Fixes #284