### PR TITLE
Ensures statuscolumn does not appear in Trouble

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -134,6 +134,7 @@ function View:setup(opts)
     wipe_rogue_buffer()
     vim.api.nvim_buf_set_name(self.buf, "Trouble")
   end
+  self:set_option("statuscolumn", "")
   self:set_option("bufhidden", "wipe")
   self:set_option("buftype", "nofile")
   self:set_option("swapfile", false)


### PR DESCRIPTION
Following Neovim >= 0.9, [statuscolumn](https://neovim.io/doc/user/options.html#'statuscolumn') was introduced. This PR ensures that it does not appear in Trouble.

##### Before:

![image](https://github.com/folke/trouble.nvim/assets/91024200/5b02352a-a0b2-4f1d-ae8c-cba6d08ea28c)


##### After:

![image](https://github.com/folke/trouble.nvim/assets/91024200/15ccaa6e-fe4f-4ae8-acd9-4ec9762dd103)


