### PR TITLE
feat: add option to control cycling of result list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Trouble comes with the following defaults:
     fold_closed = "", -- icon used for closed folds
     group = true, -- group results by file
     padding = true, -- add an extra new line on top of the list
+    cycle_results = true, -- cycle item list when reaching beginning or end of list
     action_keys = { -- key mappings for actions in the trouble list
         -- map to {} to remove a mapping, for example:
         -- close = {},

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -21,6 +21,7 @@ local defaults = {
   severity = nil, -- nil (ALL) or vim.diagnostic.severity.ERROR | WARN | INFO | HINT
   fold_open = "", -- icon used for open folds
   fold_closed = "", -- icon used for closed folds
+  cycle_results = true, -- cycle item list when reaching beginning or end of list
   action_keys = { -- key mappings for actions in the trouble list
     close = "q", -- close the list
     cancel = "<esc>", -- cancel the preview and get back to your last window / buffer / cursor

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -385,7 +385,9 @@ function View:next_item(opts)
   local line = opts.first and 0 or self:get_line() + 1
 
   if line > #self.items then
-    self:first_item(opts)
+    if config.options.cycle_results then
+      self:first_item(opts)
+    end
   else
     for i = line, vim.api.nvim_buf_line_count(self.buf), 1 do
       if self.items[i] and not (opts.skip_groups and self.items[i].is_file) then
@@ -406,7 +408,9 @@ function View:previous_item(opts)
   for i = 0, vim.api.nvim_buf_line_count(self.buf), 1 do
     if self.items[i] then
       if line < i + (opts.skip_groups and 1 or 0) then
-        self:last_item(opts)
+        if config.options.cycle_results then
+          self:last_item(opts)
+        end
         return
       end
       break


### PR DESCRIPTION
Add new cycle_results option (default: true, the current behavior), to control whether to cycle the results list when reaching the beginning or end of the list.

I find myself regularly disoriented about where I am in a list of diagnostics when I cycle back to the beginning without realizing it.  I always prefer to stop when I reach the end of the list so that it's obvious that I'm at the end (like setting `scroll_strategy = limit` in telescope).  Going back to the beginning is simple enough with normal vim movements.