### PR TITLE
feat: rendering messages from provider

### DIFF
--- a/lua/trouble/providers/diagnostic.lua
+++ b/lua/trouble/providers/diagnostic.lua
@@ -3,6 +3,13 @@ local util = require("trouble.util")
 ---@class Lsp
 local M = {}
 
+local severity = {
+  [1] = "ERROR",
+  [2] = "WARN",
+  [3] = "INFO",
+  [4] = "HINT",
+}
+
 ---@param options TroubleOptions
 ---@return Item[]
 function M.diagnostics(_, buf, cb, options)
@@ -23,7 +30,13 @@ function M.diagnostics(_, buf, cb, options)
     items = util.locations_to_items(diags, 1)
   end
 
-  cb(items)
+  local messages = {}
+  if options.severity ~= nil then
+    table.insert(messages, { text = "filter:", group = "Information" })
+    table.insert(messages, { text = severity[options.severity], group = "Sign" .. util.severity[options.severity] })
+  end
+
+  cb(items, messages)
 end
 
 function M.get_signs()

--- a/lua/trouble/providers/init.lua
+++ b/lua/trouble/providers/init.lua
@@ -52,7 +52,7 @@ function M.get(win, buf, cb, options)
     end,
   }, options.sort_keys)
 
-  provider(win, buf, function(items)
+  provider(win, buf, function(items, messages)
     table.sort(items, function(a, b)
       for _, key in ipairs(sort_keys) do
         local ak = type(key) == "string" and a[key] or key(a)
@@ -62,7 +62,7 @@ function M.get(win, buf, cb, options)
         end
       end
     end)
-    cb(items)
+    cb(items, messages)
   end, options)
 end
 

--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -34,7 +34,7 @@ end
 function renderer.render(view, opts)
   opts = opts or {}
   local buf = vim.api.nvim_win_get_buf(view.parent)
-  providers.get(view.parent, buf, function(items)
+  providers.get(view.parent, buf, function(items, messages)
     local auto_jump = vim.tbl_contains(config.options.auto_jump, opts.mode)
     if opts.on_open and #items == 1 and auto_jump and not opts.auto then
       view:close()
@@ -60,6 +60,11 @@ function renderer.render(view, opts)
     view.items = {}
 
     if config.options.padding then
+      if messages ~= nil then
+        for _, msg in ipairs(messages) do
+          text:render(" " .. msg.text, msg.group, { append = " " })
+        end
+      end
       text:nl()
     end
 


### PR DESCRIPTION
use the padded line as a status bar, so we can display some messages from the provider

for example, in the `diagnostics` mode,  we can show it's current severity filter in it.
 
![image](https://github.com/folke/trouble.nvim/assets/2351076/98ab3806-cd76-4b0d-881e-27e7ee8223c2)

#301 
