### PR TITLE
Use code descriptions for opening URIs with extra information

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Trouble comes with the following defaults:
         toggle_preview = "P", -- toggle auto_preview
         hover = "K", -- opens a small popup with the full multiline message
         preview = "p", -- preview the diagnostic location
+        open_code_href = "c", -- if present, open a URI with more information about the diagnostic error
         close_folds = {"zM", "zm"}, -- close all folds
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -36,6 +36,7 @@ local defaults = {
     toggle_preview = "P", -- toggle auto_preview
     hover = "K", -- opens a small popup with the full multiline message
     preview = "p", -- preview the diagnostic location
+    open_code_href = "c", -- if present, open a URI with more information about the diagnostic error
     close_folds = { "zM", "zm" }, -- close all folds
     open_folds = { "zR", "zr" }, -- open all folds
     toggle_fold = { "zA", "za" }, -- toggle fold of current file

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -256,6 +256,9 @@ function Trouble.action(action)
   if action == "preview" then
     view:preview()
   end
+  if action == "open_code_href" then
+    view:open_code_href()
+  end
 
   if Trouble[action] then
     Trouble[action]()

--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -123,11 +123,9 @@ end
 
 -- based on the Telescope diagnostics code
 -- see https://github.com/nvim-telescope/telescope.nvim/blob/0d6cd47990781ea760dd3db578015c140c7b9fa7/lua/telescope/utils.lua#L85
-
 function M.process_item(item, bufnr)
   bufnr = bufnr or item.bufnr
   local filename = vim.api.nvim_buf_get_name(bufnr)
-  local uri = vim.uri_from_bufnr(bufnr)
   local range = item.range or item.targetSelectionRange
 
   local start = {
@@ -183,6 +181,13 @@ function M.process_item(item, bufnr)
     full_text = vim.trim(item.message),
     type = M.severity[item.severity] or M.severity[0],
     code = item.code or (item.user_data and item.user_data.lsp and item.user_data.lsp.code), ---@type string?
+    code_href = (item.codeDescription and item.codeDescription.href)
+      or (
+        item.user_data
+        and item.user_data.lsp
+        and item.user_data.lsp.codeDescription
+        and item.user_data.lsp.codeDescription.href
+      ), ---@type string?
     source = item.source, ---@type string?
     severity = item.severity or 0,
   }

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -521,4 +521,41 @@ end
 
 View.preview = util.throttle(50, View._preview)
 
+function View:open_code_href()
+  if not vim.api.nvim_win_is_valid(self.parent) then
+    return
+  end
+
+  local item = self:current_item()
+  if not item then
+    return
+  end
+  util.debug("open code href")
+
+  if item.is_file ~= true and item.code_href then
+    local cmd
+    if vim.fn.has("win32") == 1 then
+      cmd = "explorer"
+    elseif vim.fn.has("macunix") == 1 then
+      cmd = "open"
+    elseif vim.fn.executable("xdg-open") == 1 then
+      cmd = "xdg-open"
+    elseif vim.fn.executable("wslview") == 1 then
+      cmd = "wslview"
+    else
+      cmd = "open"
+    end
+
+    local ret = vim.fn.jobstart({ cmd, item.code_href }, { detach = true })
+    if ret <= 0 then
+      local msg = {
+        "Failed to open code href",
+        ret,
+        vim.inspect(cmd),
+      }
+      vim.notify(table.concat(msg, "\n"), vim.log.levels.ERROR)
+    end
+  end
+end
+
 return View

--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -536,8 +536,6 @@ function View:open_code_href()
     local cmd
     if vim.fn.has("win32") == 1 then
       cmd = "explorer"
-    elseif vim.fn.has("macunix") == 1 then
-      cmd = "open"
     elseif vim.fn.executable("xdg-open") == 1 then
       cmd = "xdg-open"
     elseif vim.fn.executable("wslview") == 1 then


### PR DESCRIPTION
LSP diagnostics can have [`codeDescription`s](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeDescription), which contain a link with more information about the error. This PR adds a new action to open these from Trouble :)