### PR TITLE
Expose help action

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Trouble comes with the following defaults:
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
         next = "j" -- next item
+        help = "?" -- help menu
     },
     multiline = true, -- render multi-line messages
     indent_lines = true, -- add an indent guide below the fold icons

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -41,6 +41,7 @@ local defaults = {
     toggle_fold = { "zA", "za" }, -- toggle fold of current file
     previous = "k", -- preview item
     next = "j", -- next item
+    help = "?", -- help menu
   },
   multiline = true, -- render multi-line messages
   indent_lines = true, -- add an indent guide below the fold icons

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -110,12 +110,7 @@ function Trouble.help()
     height = height + 1
   end
   -- help
-  vim.lsp.util.open_floating_preview(lines, "markdown", {
-    border = "single",
-    height = 20,
-    offset_y = -2,
-    offset_x = 2,
-  })
+  vim.lsp.util.open_floating_preview(lines, "markdown", { border = "single" })
 end
 
 local updater = util.debounce(100, function()


### PR DESCRIPTION
Okay I promise this is the last PR I create today lol.

I noticed earlier that there's a `Trouble.help()` implementation but no action for it. I find it quite useful and so this PR adds a keymapping to open the help window.