### PR TITLE
Create Configuration for IncludeDeclaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Trouble comes with the following defaults:
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
     auto_fold = false, -- automatically fold a file trouble list at creation
     auto_jump = {"lsp_definitions"}, -- for the given modes, automatically jump if there is only a single result
+    include_declaration = { "lsp_references", "lsp_implementations", "lsp_definitions"  }, -- for the given modes, include the declaration of the current symbol in the results
     signs = {
       -- icons / text used for a diagnostic
       error = "",

--- a/doc/trouble.nvim.txt
+++ b/doc/trouble.nvim.txt
@@ -115,6 +115,7 @@ Trouble comes with the following defaults:
         auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
         auto_fold = false, -- automatically fold a file trouble list at creation
         auto_jump = {"lsp_definitions"}, -- for the given modes, automatically jump if there is only a single result
+	include_declaration = { "lsp_references", "lsp_implementations", "lsp_definitions"  }, -- for the given modes, include the declaration of the current symbol in the results
         signs = {
           -- icons / text used for a diagnostic
           error = "",

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -49,6 +49,7 @@ local defaults = {
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
   auto_fold = false, -- automatically fold a file trouble list at creation
   auto_jump = { "lsp_definitions" }, -- for the given modes, automatically jump if there is only a single result
+  include_declaration = { "lsp_references", "lsp_implementations", "lsp_definitions"  }, -- for the given modes, include the declaration of the current symbol in the results
   signs = {
     -- icons / text used for a diagnostic
     error = "",

--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -11,10 +11,11 @@ local function lsp_buf_request(buf, method, params, handler)
 end
 
 ---@return Item[]
-function M.references(win, buf, cb, _options)
+function M.references(win, buf, cb, options)
   local method = "textDocument/references"
   local params = util.make_position_params(win, buf)
-  params.context = { includeDeclaration = true }
+  params.context = { includeDeclaration = vim.tbl_contains(options.include_declaration, options.mode) }
+
   lsp_buf_request(buf, method, params, function(err, result)
     if err then
       util.error("an error happened getting references: " .. err.message)
@@ -29,10 +30,10 @@ function M.references(win, buf, cb, _options)
 end
 
 ---@return Item[]
-function M.implementations(win, buf, cb, _options)
+function M.implementations(win, buf, cb, options)
   local method = "textDocument/implementation"
   local params = util.make_position_params(win, buf)
-  params.context = { includeDeclaration = true }
+  params.context = { includeDeclaration = vim.tbl_contains(options.include_declaration, options.mode) }
   lsp_buf_request(buf, method, params, function(err, result)
     if err then
       util.error("an error happened getting implementation: " .. err.message)
@@ -47,10 +48,10 @@ function M.implementations(win, buf, cb, _options)
 end
 
 ---@return Item[]
-function M.definitions(win, buf, cb, _options)
+function M.definitions(win, buf, cb, options)
   local method = "textDocument/definition"
   local params = util.make_position_params(win, buf)
-  params.context = { includeDeclaration = true }
+  params.context = { includeDeclaration = vim.tbl_contains(options.include_declaration, options.mode) }
   lsp_buf_request(buf, method, params, function(err, result)
     if err then
       util.error("an error happened getting definitions: " .. err.message)


### PR DESCRIPTION
## Context

Currently, when `references`, `implementations`, or `definitions`  is called, `includeDeclaration` is set to `true` by default.

This is cumbersome when you are on a definition and call `lsp_references` when there is only 1 reference. Instead of instantly jumping to said reference, a Trouble window appears including that sole reference as well as the your current position.  

I'm sure there may be other scenarios, but this is the one I most frequently run into. 

## This PR

This PR adds a `include_declaration` list in the config. Only modes that are in this list will `include_declaration` set to `true`. All current modes using it have been set as a default so it doesn't break anyones workflow.