### PR TITLE
Fix lua keybindings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ nnoremap gR <cmd>TroubleToggle lsp_references<cr>
 vim.keymap.set("n", "<leader>xx", function() require("trouble").open() end)
 vim.keymap.set("n", "<leader>xw", function() require("trouble").open("workspace_diagnostics") end)
 vim.keymap.set("n", "<leader>xd", function() require("trouble").open("document_diagnostics") end)
-vim.keymap.set("n", "<leader>xl", function() require("trouble").open("quickfix") end)
-vim.keymap.set("n", "<leader>xq", function() require("trouble").open("loclist") end)
+vim.keymap.set("n", "<leader>xq", function() require("trouble").open("quickfix") end)
+vim.keymap.set("n", "<leader>xl", function() require("trouble").open("loclist") end)
 vim.keymap.set("n", "gR", function() require("trouble").open("lsp_references") end)
 ```
 


### PR DESCRIPTION
The lua keybinds below were like this:

```
vim.keymap.set("n", "<leader>xl", function() require("trouble").open("quickfix") end)
vim.keymap.set("n", "<leader>xq", function() require("trouble").open("loclist") end)
```

As it might not be noticeable the `<leader>xl` keybinding was opening the `quickfix` and the `<leader>xq` keybinding was opening the `loclist`.

So I thought about changing the order just to be more straight forward to new users and to be in sync with the vim keybindings above the lua ones and the result was:
```
vim.keymap.set("n", "<leader>xq", function() require("trouble").open("quickfix") end)
vim.keymap.set("n", "<leader>xl", function() require("trouble").open("loclist") end)
```