### PR TITLE
feat: Add ability to define severity for `auto_open`

### DIFF
--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -47,7 +47,7 @@ local defaults = {
   multiline = true, -- render multi-line messages
   indent_lines = true, -- add an indent guide below the fold icons
   win_config = { border = "single" }, -- window configuration for floating windows. See |nvim_open_win()|.
-  auto_open = false, -- automatically open the list when you have diagnostics
+  auto_open = false, -- automatically open the list when you have diagnostics, set to true to open on any severity, or define a map of vim.diagnostic.severity for specific severities
   auto_close = false, -- automatically close the list when you have no diagnostics
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
   auto_fold = false, -- automatically fold a file trouble list at creation

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -153,7 +153,18 @@ function Trouble.refresh(opts)
   elseif opts.auto and config.options.auto_open and opts.provider == config.options.mode then
     require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
       if #results > 0 then
-        Trouble.open(opts)
+        for _, result in ipairs(results) do
+          if config.options.auto_open ~= true then
+            for _, auto_sev in ipairs(config.options.auto_open) do
+              if result.severity == auto_sev then
+                Trouble.open(opts)
+                return
+              end
+            end
+          else
+            Trouble.open(opts)
+          end
+        end
       end
     end, config.options)
   end

--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -47,9 +47,26 @@ function renderer.render(view, opts)
 
     -- check for auto close
     if opts.auto and config.options.auto_close then
-      if count == 0 then
-        view:close()
-        return
+      local count_in_severity = 0
+
+      if config.options.auto_open and config.options.auto_open ~= true then
+        for _, auto_sev in ipairs(config.options.auto_open) do
+          for _, item in ipairs(items) do
+            if item.severity == auto_sev then
+              count_in_severity = count_in_severity + 1
+            end
+          end
+        end
+
+        if count_in_severity == 0 then
+          view:close()
+          return
+        end
+      else
+        if count == 0 then
+          view:close()
+          return
+        end
       end
     end
 


### PR DESCRIPTION
Some LSPs are very noisy, and its very distracting to have trouble automatically open when the message is not important.

Also setting the global severity doesn't leave you a choice to deal with useful messages.

This PR allows you to define a map of `vim.diagnostic.severity` on the `auto_open` option to only open trouble when any of the results severities matches the list.