### PR TITLE
docs: update defaults example to valid lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Trouble comes with the following defaults:
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
-        next = "j" -- next item
-        help = "?" -- help menu
+        next = "j", -- next item
+        help = "?",-- help menu
     },
     multiline = true, -- render multi-line messages
     indent_lines = true, -- add an indent guide below the fold icons
@@ -108,7 +108,7 @@ Trouble comes with the following defaults:
       information = "",
       other = "",
     },
-    use_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
+    use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
 }
 ```
 


### PR DESCRIPTION
I copy pasted the defaults from the README into my config when testing out the plugin and was greeted by an error. Wanted to help other lazy users like myself in the future.
 
When I took a look at the actual defaults files i noticed the [sort_keys table]( https://github.com/folke/trouble.nvim/blob/main/lua/trouble/config.lua#L65) was also missing from the README. I considered adding it to this pr, but assumed it was left out on purpose since there were no comments on these lines. 

