### PR TITLE
fix: only filter msg if sev is hardcoded

### DIFF
--- a/lua/trouble/providers/diagnostic.lua
+++ b/lua/trouble/providers/diagnostic.lua
@@ -31,7 +31,7 @@ function M.diagnostics(_, buf, cb, options)
   end
 
   local messages = {}
-  if options.severity ~= nil then
+  if severity[options.severity] then
     table.insert(messages, { text = "filter:", group = "Information" })
     table.insert(messages, { text = severity[options.severity], group = "Sign" .. util.severity[options.severity] })
   end


### PR DESCRIPTION
Fixes previous breaking change #304 that prevented nvim severity tables from working, such as:
```
require("trouble").setup({
	severity = { min = vim.diagnostic.severity.INFO },
})
```
Optimal fix might be a less naive way of filtering severity, but I'd leave that for somebody that cares about this feature.