### PR TITLE
fix(docs): missing commas in default config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Trouble comes with the following defaults:
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
-        next = "j" -- next item
-        help = "?" -- help menu
+        next = "j", -- next item
+        help = "?", -- help menu
     },
     multiline = true, -- render multi-line messages
     indent_lines = true, -- add an indent guide below the fold icons

--- a/doc/trouble.nvim.txt
+++ b/doc/trouble.nvim.txt
@@ -107,8 +107,8 @@ Trouble comes with the following defaults:
             open_folds = {"zR", "zr"}, -- open all folds
             toggle_fold = {"zA", "za"}, -- toggle fold of current file
             previous = "k", -- previous item
-            next = "j" -- next item
-            help = "?" -- help menu
+            next = "j", -- next item
+            help = "?", -- help menu
         },
         multiline = true, -- render multi-line messages
         indent_lines = true, -- add an indent guide below the fold icons


### PR DESCRIPTION
The _Readme_'s are missing two commas in the default config example. I noticed this after copying it as i always do to tweak configs to my liking. I figured this was worth "fixing" in order to save others the trouble.

Feel free to discard this PR.