### PR TITLE
feat: add an option to not open trouble with empty list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Trouble comes with the following defaults:
     multiline = true, -- render multi-line messages
     indent_lines = true, -- add an indent guide below the fold icons
     win_config = { border = "single" }, -- window configuration for floating windows. See |nvim_open_win()|.
+    lsp_open_empty = true, -- open the list when you have no lsp results
     auto_open = false, -- automatically open the list when you have diagnostics
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -47,6 +47,7 @@ local defaults = {
   multiline = true, -- render multi-line messages
   indent_lines = true, -- add an indent guide below the fold icons
   win_config = { border = "single" }, -- window configuration for floating windows. See |nvim_open_win()|.
+  lsp_open_empty = true, -- open the list when you have no lsp results
   auto_open = false, -- automatically open the list when you have diagnostics
   auto_close = false, -- automatically close the list when you have no diagnostics
   auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window

--- a/lua/trouble/init.lua
+++ b/lua/trouble/init.lua
@@ -78,6 +78,12 @@ function Trouble.open(...)
         view = View.create(opts)
       end
     end, config.options)
+  elseif not opts.auto and not config.options.lsp_open_empty and opts.mode:find('lsp', 1, true) then
+    require("trouble.providers").get(vim.api.nvim_get_current_win(), vim.api.nvim_get_current_buf(), function(results)
+      if #results > 0 then
+        view = View.create(opts)
+      end
+    end, config.options)
   else
     view = View.create(opts)
   end


### PR DESCRIPTION
This PR add an option to not open trouble with an empty list.

Works as I expect it to, does not interfere with diagnostics and quickfix/loclist. 
I'm not sure if the place to check the option is the right one. If not please tell me.