### PR TITLE
fix(preview): skip non-existing. Fixes #87. Fixes #188. Fixes #336.

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -495,6 +495,10 @@ function View:_preview()
   if not item then
     return
   end
+  if item.bufnr == 0 then
+    return
+  end
+
   util.debug("preview")
 
   if item.is_file ~= true then


### PR DESCRIPTION
Continuation of 46b60e9.

Skip preview for non-existing buffer (`bufnr == 0`).

The vim docs say:

```
getqflist()

Quickfix list entries with a non-existing buffer
 number are returned with "bufnr" set to zero (Note: some
 functions accept buffer number zero for the alternate buffer,
 you may need to explicitly check for zero).
```

This causes trouble for the "`Trouble`" file section:

![](https://user-images.githubusercontent.com/721196/260180476-286d5945-2f53-4f2c-aedc-af793c0e96db.png)

To fix, we simply do:

```lua
function View:_preview()
  ...

  if item.bufnr == 0 then
    return
  end

  util.debug("preview")
  ...
end
```