### PR TITLE
fix: add guards to check for deleted parent windows

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -304,7 +304,7 @@ function View:on_win_enter()
 
   -- check if another buffer took over our window
   local parent = self.parent
-  if current_win == self.win and current_buf ~= self.buf then
+  if current_win == self.win and current_buf ~= self.buf and vim.api.nvim_win_is_valid(parent) then
     -- open the buffer in the parent
     vim.api.nvim_win_set_buf(parent, current_buf)
     -- HACK: some window local settings need to be reset
@@ -353,8 +353,8 @@ function View:close()
   if vim.api.nvim_win_is_valid(self.win) then
     if vim.api.nvim_win_is_valid(self.parent) then
       vim.api.nvim_set_current_win(self.parent)
+      vim.api.nvim_win_close(self.win, {})
     end
-    vim.api.nvim_win_close(self.win, {})
   end
   if vim.api.nvim_buf_is_valid(self.buf) then
     vim.api.nvim_buf_delete(self.buf, {})


### PR DESCRIPTION
Fixes #284 and #253 

The line moved on line 356 is to get rid of the error for `Vim:E444: Cannot close last window`, which will show up if the parent is invalid.

The added check on line 307 is to fix the error: `E565: Not allowed to change text or change window` which errors on line 309 when the parent is invalid.

Both cases can be reproduced by having 2 or more buffers open, opening Trouble, then using `:bdelete` to delete your current "parent" buffer
