### PR TITLE
Fix error when item.filename is nil

### DIFF
--- a/lua/trouble/providers/telescope.lua
+++ b/lua/trouble/providers/telescope.lua
@@ -9,7 +9,7 @@ local function item_to_result(item)
   local row = (item.lnum or 1) - 1
   local col = (item.col or 1) - 1
 
-  if not item.bufnr then
+  if item.filename and not item.bufnr then
     local fname = vim.fn.fnamemodify(item.filename, ":p")
     if vim.fn.filereadable(fname) == 0 and item.cwd then
       fname = vim.fn.fnamemodify(item.cwd .. "/" .. item.filename, ":p")


### PR DESCRIPTION
I'm using telescope-file-browser, and whenever I pressed the change_cwd action (https://github.com/nvim-telescope/telescope-file-browser.nvim#mappings) I got the following error from trouble.nvim:
```
E5108: Error executing lua: ...im/lazy/trouble.nvim/lua/trouble/providers/telescope.lua:15: attempt to concatenate field 'filename' (a nil value)
```
This PR fixes this.