### PR TITLE
docs: defaults config typo. Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Trouble comes with the following defaults:
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
-        next = "j" -- next item
+        next = "j", -- next item
         help = "?" -- help menu
     },
     multiline = true, -- render multi-line messages


### PR DESCRIPTION
A forgotten little comma.