### PR TITLE
auto-close notification

### DIFF
--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -48,6 +48,7 @@ function renderer.render(view, opts)
     -- check for auto close
     if opts.auto and config.options.auto_close then
       if count == 0 then
+        vim.notify("No results found", vim.log.levels.INFO)
         view:close()
         return
       end


### PR DESCRIPTION
Hey! I like the auto-close option so we don't end with an empty split open, but having no feedback at all is confusing and sometimes leds you to think that the command just didn't work.

This PR just adds an info notification so the user could see that no results was found, and in that way be aware that's why nothing happened.

Feel free to suggest other message in the text or a different way of notifying the user.

Thanks for the plugin!