### PR TITLE
Fix lsp provider when lsp does not return an array

### DIFF
--- a/lua/trouble/providers/lsp.lua
+++ b/lua/trouble/providers/lsp.lua
@@ -22,7 +22,11 @@ function M.references(win, buf, cb, options)
       return cb({})
     end
     if result == nil or #result == 0 then
-      return cb({})
+      if vim.tbl_isempty(result) then
+        return cb({})
+      else
+        result = { result }
+      end
     end
     local ret = util.locations_to_items({ result }, 0)
     cb(ret)
@@ -40,7 +44,11 @@ function M.implementations(win, buf, cb, options)
       return cb({})
     end
     if result == nil or #result == 0 then
-      return cb({})
+      if vim.tbl_isempty(result) then
+        return cb({})
+      else
+        result = { result }
+      end
     end
     local ret = util.locations_to_items({ result }, 0)
     cb(ret)
@@ -58,7 +66,11 @@ function M.definitions(win, buf, cb, options)
       return cb({})
     end
     if result == nil or #result == 0 then
-      return cb({})
+      if vim.tbl_isempty(result) then
+        return cb({})
+      else
+        result = { result }
+      end
     end
     for _, value in ipairs(result) do
       value.uri = value.targetUri or value.uri


### PR DESCRIPTION
Hey, hello, I was using Trouble with [rescript-language-server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rescriptls) and I was having issues using lsp provider, it wasn't working, so when I debbuged the issue I found that rescript-language-server was responding the follow to the `lsp_buf_request` function:

```lua
{
  range = {
    ["end"] = {
      character = 23,
      line = 1
    },
    start = {
      character = 6,
      line = 1
    }
  },
  uri = "file:///Users/matheus.ashton/dev/pessoal/rsus/src/Transactions/TransactionsPage.res"
}
```

And in [here](https://github.com/folke/trouble.nvim/blob/f1168feada93c0154ede4d1fe9183bf69bac54ea/lua/trouble/providers/lsp.lua#L42) the evaluation of `#result == 0` is true, because the length operator works differently if the table has not an array part: 
https://stackoverflow.com/a/23591039

So it understands that there is no result at all, but in fact it is just not formatted right.

So I added a `vim.tbl_isempty` inside each test in order to check if it's indeed has no result or if it just don't have and array part in the table.

This fixed the issue for me.

PS: Also, if you check this same case comparing the behavior of `vim.lsp.buf.definition()` it works normally.