### PR TITLE
feat: add 'append' option to telescope provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,17 @@ telescope.setup {
 }
 ```
 
-When you open telescope, you can now hit `<c-t>` to open the results in **Trouble**
+When you open telescope, you can now hit `<c-t>` to open the results in **Trouble**.
+
+You can also choose to *append* to the **Trouble** list, by using something like
+```lua
+function(nr, mode) trouble.open_with_trouble(nr, mode, { append = true }) end
+```
+as action.
+
+There's also `open_selected_with_trouble` and `smart_open_with_trouble`; the latter one
+opens selected results, if any results are selected, and otherwise opens all search
+results.
 
 ## 🎨 Colors
 

--- a/lua/trouble/providers/telescope.lua
+++ b/lua/trouble/providers/telescope.lua
@@ -32,13 +32,15 @@ local function item_to_result(item)
 end
 
 --- Shows all Telescope results in Trouble.
-function M.open_with_trouble(prompt_bufnr, _mode)
+--- Set 'append' to true to append to the trouble list instead of replacing it.
+function M.open_with_trouble(prompt_bufnr, _mode, opts)
+  opts = opts or {}
   local action_state = require("telescope.actions.state")
   local actions = require("telescope.actions")
   local picker = action_state.get_current_picker(prompt_bufnr)
   local manager = picker.manager
 
-  M.results = {}
+  M.results = opts.append and M.results or {}
   for item in manager:iter() do
     table.insert(M.results, item_to_result(item))
   end
@@ -48,12 +50,14 @@ function M.open_with_trouble(prompt_bufnr, _mode)
 end
 
 --- Shows the selected Telescope results in Trouble.
-function M.open_selected_with_trouble(prompt_bufnr, _mode)
+--- Set 'append' to true to append to the trouble list instead of replacing it.
+function M.open_selected_with_trouble(prompt_bufnr, _mode, opts)
+  opts = opts or {}
   local action_state = require("telescope.actions.state")
   local actions = require("telescope.actions")
   local picker = action_state.get_current_picker(prompt_bufnr)
 
-  M.results = {}
+  M.results = opts.append and M.results or {}
   for _, item in ipairs(picker:get_multi_selection()) do
     table.insert(M.results, item_to_result(item))
   end
@@ -64,13 +68,14 @@ end
 
 --- Shows the selected Telescope results in Trouble.
 --- If no results are currently selected, shows all of them.
-function M.smart_open_with_trouble(prompt_bufnr, _mode)
+--- Set 'append' to true to append to the trouble list instead of replacing it.
+function M.smart_open_with_trouble(prompt_bufnr, _mode, opts)
   local action_state = require("telescope.actions.state")
   local picker = action_state.get_current_picker(prompt_bufnr)
   if #picker:get_multi_selection() > 0 then
-    M.open_selected_with_trouble(prompt_bufnr, _mode)
+    M.open_selected_with_trouble(prompt_bufnr, _mode, opts)
   else
-    M.open_with_trouble(prompt_bufnr, _mode)
+    M.open_with_trouble(prompt_bufnr, _mode, opts)
   end
 end
 


### PR DESCRIPTION
This features enables users to create a telescope action which *appends* search results to the trouble list, instead of replacing the whole list.

I thought I would also add a comment about `open_selected_with_trouble` and `smart_open_with_trouble` to the README because I actually only found out about them when implementing the *append* feature.