### PR TITLE
fix: gracefully fail when devicon is not available

### DIFF
--- a/lua/trouble/renderer.lua
+++ b/lua/trouble/renderer.lua
@@ -19,7 +19,7 @@ local function get_icon(file)
   end
   local fname = vim.fn.fnamemodify(file, ":t")
   local ext = vim.fn.fnamemodify(file, ":e")
-  return icons.get_icon(fname, ext, { default = true })
+  return icons.get_icon(fname, ext, { default = true }) or ""
 end
 
 local function update_signs()


### PR DESCRIPTION
A very basic fix for #383 that appears to completely alleviate the issue, though there might be better ways of addressing this.