### PR TITLE
docs: adding missing commas to config setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Trouble comes with the following defaults:
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
-        next = "j" -- next item
-        help = "?" -- help menu
+        next = "j", -- next item
+        help = "?", -- help menu
     },
     multiline = true, -- render multi-line messages
     indent_lines = true, -- add an indent guide below the fold icons
@@ -118,7 +118,7 @@ Trouble comes with the following defaults:
       information = "",
       other = "",
     },
-    use_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
+    use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
 }
 ```
 

--- a/doc/trouble.nvim.txt
+++ b/doc/trouble.nvim.txt
@@ -118,8 +118,8 @@ Trouble comes with the following defaults:
             open_folds = {"zR", "zr"}, -- open all folds
             toggle_fold = {"zA", "za"}, -- toggle fold of current file
             previous = "k", -- previous item
-            next = "j" -- next item
-            help = "?" -- help menu
+            next = "j", -- next item
+            help = "?", -- help menu
         },
         multiline = true, -- render multi-line messages
         indent_lines = true, -- add an indent guide below the fold icons
@@ -138,7 +138,7 @@ Trouble comes with the following defaults:
           information = "",
           other = "",
         },
-        use_diagnostic_signs = false -- enabling this will use the signs defined in your lsp client
+        use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
     }
 <
 


### PR DESCRIPTION
Noticed these commas were missing while doing some copy-pasting, they are in place correctly in [lua/trouble/config.lua](https://github.com/matthew-hagemann/trouble.nvim/blob/main/lua/trouble/config.lua#L44)

