### PR TITLE
Fixed a syntactical mistake in README.md -- setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Trouble comes with the following defaults:
         open_folds = {"zR", "zr"}, -- open all folds
         toggle_fold = {"zA", "za"}, -- toggle fold of current file
         previous = "k", -- previous item
-        next = "j" -- next item
+        next = "j", -- next item
         help = "?" -- help menu
     },
     multiline = true, -- render multi-line messages


### PR DESCRIPTION
A comma was missing in the `Setup` section of the Readme, simple fix.