### PR TITLE
chore(README): mention `opts` in install

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Install the plugin with your preferred package manager:
       desc = "Quickfix List (Trouble)",
     },
   },
+  opts = {}, -- for default options, refer to the configuration section for custom setup.
 }
 ```
 


### PR DESCRIPTION
The `Trouble` command is only exposed if we call `opts` or `config` when installing the plugin, it should be documented.

Alternatively, since the default options works well, it would be great to make the plugin config-less by exposing [something like this](https://github.com/shortcuts/no-neck-pain.nvim/blob/main/plugin/no-neck-pain.lua) (_not trying to promo the repository, just using it as an example, feel free to edit the PR body if you feel like it_)