### PR TITLE
Support vim.loop for Neovim < 0.10 and vim.uv for 0.10 and greater

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -75,7 +75,7 @@
             severity = vim.diagnostic.severity.ERROR, -- errors only
             -- limit to files in the current project
             function(item)
-              return item.filename:find(vim.loop.cwd(), 1, true)
+              return item.filename:find((vim.loop or vim.uv).cwd(), 1, true)
             end,
           },
         },

--- a/lua/trouble/async.lua
+++ b/lua/trouble/async.lua
@@ -1,14 +1,15 @@
 local M = {}
+local uv = vim.loop or vim.uv
 
 M.budget = 1
 local Scheduler = {}
 Scheduler._queue = {}
-Scheduler._executor = assert(vim.loop.new_check())
+Scheduler._executor = assert(uv.new_check())
 
 function Scheduler.step()
   local budget = M.budget * 1e6
-  local start = vim.loop.hrtime()
-  while #Scheduler._queue > 0 and vim.loop.hrtime() - start < budget do
+  local start = uv.hrtime()
+  while #Scheduler._queue > 0 and uv.hrtime() - start < budget do
     local a = table.remove(Scheduler._queue, 1)
     a:_step()
     if a.running then

--- a/lua/trouble/sources/diagnostics.lua
+++ b/lua/trouble/sources/diagnostics.lua
@@ -35,7 +35,7 @@ M.config = {
       --   },
       -- },
       -- function(item)
-      --   return item.filename:find(vim.loop.cwd(), 1, true)
+      --   return item.filename:find((vim.loop or vim.uv).cwd(), 1, true)
       -- end,
       -- },
     },

--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -1,5 +1,5 @@
 local Config = require("trouble.config")
-local uv = vim.loop
+local uv = vim.loop or vim.uv
 
 local M = {}
 
@@ -100,7 +100,7 @@ function M.throttle(fn, opts)
   opts.ms = opts.ms or 20
   local last = 0
   local args = nil ---@type {n?:number}?
-  local timer = assert(vim.loop.new_timer())
+  local timer = assert(uv.new_timer())
   local pending = false -- from run() till end of fn
   local running = false -- from run() till end of fn with is_running()
 
@@ -110,7 +110,7 @@ function M.throttle(fn, opts)
     pending = true
     running = true
     timer:stop()
-    last = vim.uv.now()
+    last = uv.now()
     vim.schedule(function()
       xpcall(function()
         if not args then
@@ -129,7 +129,7 @@ function M.throttle(fn, opts)
   end
 
   function t.schedule()
-    local now = vim.uv.now()
+    local now = uv.now()
     local delay = opts.debounce and opts.ms or (opts.ms - (now - last))
     timer:stop()
     timer:start(math.max(0, delay), 0, t.run)
@@ -144,7 +144,7 @@ function M.throttle(fn, opts)
     end
   end
 
-  local check = assert(vim.uv.new_check())
+  local check = assert(uv.new_check())
   check:start(t.check)
 
   return function(...)

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -1,4 +1,5 @@
 local M = {}
+local uv = vim.loop or vim.uv
 
 function M.root(root)
   local f = debug.getinfo(1, "S").source:sub(2)
@@ -9,7 +10,7 @@ end
 function M.load(plugin)
   local name = plugin:match(".*/(.*)")
   local package_root = M.root(".tests/site/pack/deps/start/")
-  if not vim.loop.fs_stat(package_root .. name) then
+  if not uv.fs_stat(package_root .. name) then
     print("Installing " .. plugin)
     vim.fn.mkdir(package_root, "p")
     vim.fn.system({


### PR DESCRIPTION
Resolves #416 

This change makes sure that existing uses of libuv support using both the old and new name in Neovim (vim.loop for Neovim < 0.10 and vim.uv for Neovim >= 0.10)