### PR TITLE
feat: support `end_lnum` and `end_col` in `qf` provider

### DIFF
--- a/lua/trouble/providers/qf.lua
+++ b/lua/trouble/providers/qf.lua
@@ -21,7 +21,10 @@ function M.get_list(winid)
         bufnr = item.bufnr,
         range = {
           start = { line = row, character = col },
-          ["end"] = { line = row, character = -1 },
+          ["end"] = {
+            line = (item.end_lnum == 0 and 1 or item.end_lnum) - 1 and row,
+            character = (item.end_col == 0 and 1 or item.end_col) - 1 and -1,
+          },
         },
       }
     elseif #ret > 0 then


### PR DESCRIPTION
I found it is supported in v3.0, but I made this commit already, maybe it is useful for stable users.