### PR TITLE
Minor format tweak and off-by-one fix

### DIFF
--- a/lua/trouble/format.lua
+++ b/lua/trouble/format.lua
@@ -46,7 +46,7 @@ end
 M.formatters = {
   pos = function(ctx)
     return {
-      text = "[" .. (ctx.item.pos[1] + 1) .. ", " .. ctx.item.pos[2] .. "]",
+      text = "[" .. ctx.item.pos[1] .. ", " .. (ctx.item.pos[2] + 1) .. "]",
     }
   end,
   severity = function(ctx)

--- a/lua/trouble/sources/diagnostics.lua
+++ b/lua/trouble/sources/diagnostics.lua
@@ -26,7 +26,7 @@ M.config = {
         { "filename", format = "{file_icon} {basename} {count}" },
       },
       sort = { "severity", "filename", "pos", "message" },
-      format = "{severity_icon} {message:md} {item.source} ({code}) {pos}",
+      format = "{severity_icon} {message:md} {item.source} {hl:Comment}({code}){hl} {pos}",
       -- filter = {
       -- ["not"] = {
       --   any = {

--- a/lua/trouble/sources/lsp.lua
+++ b/lua/trouble/sources/lsp.lua
@@ -68,7 +68,7 @@ M.config = {
         { "filename", format = "{file_icon} {filename} {count}" },
       },
       sort = { "filename", "pos", "text" },
-      format = "{text:ts} ({item.client}) {pos}",
+      format = "{text:ts} {item.client:Comment} {pos}",
     },
     lsp = {
       desc = "LSP definitions, references, implementations, type definitions, and declarations",
@@ -91,7 +91,7 @@ for _, mode in ipairs({ "incoming_calls", "outgoing_calls" }) do
     title = "{hl:Title}" .. Util.camel(mode, " ") .. "{hl} {count}",
     desc = Util.camel(mode, " "),
     source = "lsp." .. mode,
-    format = "{kind_icon} {chi.name} {text:ts} {pos} {hl:Title}{item.client:Title}{hl}",
+    format = "{kind_icon} {chi.name} {text:ts} {item.client:Comment} {pos}",
   }
 end
 


### PR DESCRIPTION
Firstly, thank you for developing this plugin, and for all the work you've obviously put in to the rewrite. v3 is great :heart: 

This PR just makes a minor tweak and fixes an off-by-one error.

The off-by-one is for the `[row, col]` display. `ctx.item.pos` seems to be `(1, 0)` indexed, so the `+1` should be on the column, not the row.

The tweak is for the formatting of an item's "source". Currently there are three different ways this is displayed: 
- Diagnostics have the source highlighted as a comment, before the position
- LSP definitions/references/etc have the client name highlighted as normal text, in brackets, before the position
- LSP incoming/outgoing calls have the client name highlighted as a "Title", without brackets, after the position

What I've done is change the LSP format strings to be more like the diagnostics one. This is what looks the nicest imo, but I don't really have a strong opinion here so if you feel differently then I don't mind changing it.

I've also changed the diagnostic formatting, so that the brackets around the code are also highlighted as a comment. Currently the brackets are shown as normal text, which looks a bit off to me, but again it's not a big deal and I wouldn't mind changing/reverting it.

These changes seem to work for me, but the code is quite complicated and I don't really understand much of what's going on - so it's very possible I've done something very wrong or missed something. Please feel free to fix/change anything if needed.