### PR TITLE
fix(utils): use `vim.loop or vim.uv` declared in the beginning of a file

### DIFF
--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -12,7 +12,7 @@ function M.noautocmd(fn)
 end
 
 function M.is_win()
-  return vim.uv.os_uname().sysname:find("Windows") ~= nil
+  return uv.os_uname().sysname:find("Windows") ~= nil
 end
 
 ---@param opts? {msg?: string}


### PR DESCRIPTION
Just fixes one vim.uv usage you have missed.
Thank you =)