### PR TITLE
fix: use (lnum, 0) for telescope item without col

### DIFF
--- a/lua/trouble/sources/telescope.lua
+++ b/lua/trouble/sources/telescope.lua
@@ -52,8 +52,8 @@ function M.item(item)
       filename = item.cwd .. "/" .. filename
     end
   end
-  local word = item.text and item.text:sub(item.col):match("%S+")
-  local pos = (item.lnum and item.col) and { item.lnum, item.col - 1 } or nil
+  local word = item.text and item.col and item.text:sub(item.col):match("%S+")
+  local pos = item.lnum and { item.lnum, item.col and item.col - 1 or 0 } or nil
   return Item.new({
     source = "telescope",
     buf = item.bufnr,


### PR DESCRIPTION
When sending telescope result to trouble, if there is no `col` field in the item (e.g. `telescope builtin.current_buffer_fuzzy_find`), the operation will fail with the following error:

```
E5108: Error executing lua: ...m/plugins/trouble.nvim/lua/trouble/sources/telescope.lua:55: bad argument #1 to 'sub' (number expected, got nil)
stack traceback:
        [C]: in function 'sub'
        ...m/plugins/trouble.nvim/lua/trouble/sources/telescope.lua:55: in function 'item'
        ...m/plugins/trouble.nvim/lua/trouble/sources/telescope.lua:99: in function 'add'
        ...m/plugins/trouble.nvim/lua/trouble/sources/telescope.lua:120: in function 'key_func'
        ...e/nvim/plugins/telescope.nvim/lua/telescope/mappings.lua:293: in function <...e/nvim/plugins/telescope.nvim/lua/telescope/mappings.lua:292>
```

This PR will make trouble gracefully accept items from telescope that doesn't have `col` field by setting `word = nil` and `pos = {lnum, 0}`.