### PR TITLE
feat: add trouble diagnostic counts to statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ config.defaults.actions.files["ctrl-t"] = actions.open
 
 When you open fzf-lua, you can now hit `<c-t>` to open the results in **Trouble**
 
-### Statusline Component
+### Statusline LSP Document Symbols Component
 
 Example for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim):
 
@@ -659,6 +659,41 @@ Example for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim):
     table.insert(opts.sections.lualine_c, {
       symbols.get,
       cond = symbols.has,
+    })
+  end,
+}
+```
+
+### Statusline Diagnostic Count Component
+
+Have the diagnostics counts in statusline widget match the trouble diagnostics filter you use.
+
+Example for [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim):
+
+```lua
+{
+  "nvim-lualine/lualine.nvim",
+  opts = function(_, opts)
+    local trouble = require 'trouble'
+    local troubleDignosticsCount = trouble.diagnosticsCount ({
+      -- use diagnostics mode and specify filter
+      mode = 'diagnostics',
+      filter = {
+        -- limit to files in the current project
+        function(item)
+          return item.filename:find((vim.loop or vim.uv).cwd(), 1, true)
+        end,
+      },
+      -- Or use a custom mode you created that already contains the filter
+      -- mode = 'onlyworkspace',
+    })
+    table.insert(opts.sections.lualine_c, {
+      'diagnostics',
+      sources = {
+        function()
+          return troubleDignosticsCount.get()
+        end,
+      },
     })
   end,
 }

--- a/lua/trouble/view/text.lua
+++ b/lua/trouble/view/text.lua
@@ -122,6 +122,26 @@ function M:statusline(opts)
   return table.concat(lines, sep)
 end
 
+---@return table -- { error = count, warn = count, info = count, hint = count }
+function M:diagnosticCount()
+  local list = {}
+  for _, line in ipairs(self._lines) do
+    for _, segment in ipairs(line) do
+      local str = segment.str:gsub("%s+", "")
+      table.insert(list, str)
+    end
+  end
+
+  local lookupTable = {}
+  for i = 1, #list, 2 do
+    local key = list[i]:lower()
+    local value = tonumber(list[i + 1])
+    lookupTable[key] = value
+  end
+
+  return lookupTable
+end
+
 function M:render(buf)
   local lines = {}
 


### PR DESCRIPTION
Allows you to use trouble diagnostic counts on your status line. This is best used when you are running a filter on trouble diagnostics. For example, I only want to see workspace diagnostics and counts.

This is my first time writing lua code and contributing to a neovim plugin. Please be kind but brutal with feedback so that I can improve my solution and learn.

I duplicated a bunch of code in api.lua from `function M.statusline(opts)`. There is probably a way to share most of that code between it and `function M.diagnosticsCount(opts)`.

I would also eventually like to support trouble as a [diagnostic source](https://github.com/nvim-lualine/lualine.nvim?tab=readme-ov-file#diagnostics-component-options) in lualine. I am not sure how to accomplish this. It is also a little more complicated than the others as you would want to specify the mode and/or filter. If anyone has any ideas on this that would be great.