### PR TITLE
fix(docs): readme/doc example for `Trouble symbols`

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Some examples:
   - `Trouble diagnostics toggle focus=false filter.buf=0`
 - Show document symbols on the right of the current window.
   Keep the document symbols in sync with the buffer you started the command in.
-  - `Trouble symbols toggle pinned=true results.win.relative=win results.win.position=right`
+  - `Trouble symbols toggle pinned=true win.relative=win win.position=right`
 - You can use **lua** code in the options for the `Trouble` command.
   The examples below all do the same thing.
   - `Trouble diagnostics filter.severity=vim.diagnostic.severity.ERROR`

--- a/doc/trouble.nvim.txt
+++ b/doc/trouble.nvim.txt
@@ -352,7 +352,7 @@ Some examples:
     - `Trouble diagnostics toggle focus=false filter.buf=0`
 - Show document symbols on the right of the current window.
     Keep the document symbols in sync with the buffer you started the command in.
-    - `Trouble symbols toggle pinned=true results.win.relative=win results.win.position=right`
+    - `Trouble symbols toggle pinned=true win.relative=win win.position=right`
 - You can use **lua** code in the options for the `Trouble` command.
     The examples below all do the same thing.
     - `Trouble diagnostics filter.severity=vim.diagnostic.severity.ERROR`


### PR DESCRIPTION
## Description

Small mistake in the doc, maybe the API changed as some point and this wasn't updated. Stumbled over this as the version in the README didn't work for me.