### PR TITLE
fix(format): for "attempt to index local 'signs' (a boolean value)" errors in nvim-0.10.1+

### DIFF
--- a/lua/trouble/format.lua
+++ b/lua/trouble/format.lua
@@ -105,7 +105,7 @@ M.formatters = {
         signs = signs(0, 0) --[[@as vim.diagnostic.Opts.Signs]]
       end
       return {
-        text = signs.text and signs.text[severity] or sign and sign.text or name:sub(1, 1),
+        text = type(signs) == "table" and signs.text and signs.text[severity] or sign and sign.text or name:sub(1, 1),
         hl = "DiagnosticSign" .. name,
       }
     else


### PR DESCRIPTION
This PR fixes the error-spamming that happens on opening Trouble when `vim.diagnostic.config().signs(0,0)` somewhy returns boolean (but Trouble expects it to be a table)
![image](https://github.com/user-attachments/assets/99f05ccc-6de2-43cc-a747-179e767cc7b2)