### PR TITLE
feat(config): add `close` counterparts to jump split actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,10 +555,20 @@ require("trouble").jump_only(opts)
 ---@return trouble.View
 require("trouble").jump_split(opts)
 
+-- Open the item in a split and close the trouble window
+---@param opts? trouble.Mode | { new? : boolean } | string
+---@return trouble.View
+require("trouble").jump_split_close(opts)
+
 -- Open the item in a vsplit
 ---@param opts? trouble.Mode | { new? : boolean } | string
 ---@return trouble.View
 require("trouble").jump_vsplit(opts)
+
+-- Open the item in a vsplit and close the trouble window
+---@param opts? trouble.Mode | { new? : boolean } | string
+---@return trouble.View
+require("trouble").jump_vsplit_close(opts)
 
 -- Go to the last item
 ---@param opts? trouble.Mode | { new? : boolean } | string

--- a/lua/trouble/config/actions.lua
+++ b/lua/trouble/config/actions.lua
@@ -114,10 +114,24 @@ local M = {
       self:jump(ctx.item, { split = true })
     end
   end,
+  -- Open the item in a split and close the trouble window
+  jump_split_close = function(self, ctx)
+    if ctx.item then
+      self:jump(ctx.item, { split = true })
+      self:close()
+    end
+  end,
   -- Open the item in a vsplit
   jump_vsplit = function(self, ctx)
     if ctx.item then
       self:jump(ctx.item, { vsplit = true })
+    end
+  end,
+  -- Open the item in a vsplit and close the trouble window
+  jump_vsplit_close = function(self, ctx)
+    if ctx.item then
+      self:jump(ctx.item, { vsplit = true })
+      self:close()
     end
   end,
   -- Dump the item to the console


### PR DESCRIPTION
## Description
Adds `jump_split_close` and `jump_vsplit_close` actions.