### PR TITLE
perf(treesitter): set regions early

### DIFF
--- a/lua/trouble/view/treesitter.lua
+++ b/lua/trouble/view/treesitter.lua
@@ -65,13 +65,14 @@ function M._attach_lang(buf, lang, regions)
   M.cache[buf] = M.cache[buf] or {}
 
   if not M.cache[buf][lang] then
-    local ok, parser = pcall(vim.treesitter.get_parser, buf, lang)
+    local ok, parser = pcall(vim.treesitter.languagetree.new, buf, lang)
     if not ok then
       local msg = "nvim-treesitter parser missing `" .. lang .. "`"
       vim.notify_once(msg, vim.log.levels.WARN, { title = "trouble.nvim" })
       return
     end
 
+    parser:set_included_regions(vim.deepcopy(regions))
     M.cache[buf][lang] = {
       parser = parser,
       highlighter = TSHighlighter.new(parser),
@@ -80,7 +81,7 @@ function M._attach_lang(buf, lang, regions)
   M.cache[buf][lang].enabled = true
   local parser = M.cache[buf][lang].parser
 
-  parser:set_included_regions(regions)
+  parser:set_included_regions(vim.deepcopy(regions))
 end
 
 return M


### PR DESCRIPTION
The get_parser and TSHighlight:new both parse the buffer which takes a lot of time since there are many error nodes, so set regions early to prevent this.

Both get_parser and TSHighlighter.new calls this [parse](https://github.com/neovim/neovim/blob/cd8e15e3373dc9544d582640f043d3dee83a953d/runtime/lua/vim/treesitter/languagetree.lua#L424), which calls [parse_regions](https://github.com/neovim/neovim/blob/cd8e15e3373dc9544d582640f043d3dee83a953d/runtime/lua/vim/treesitter/languagetree.lua#L340), and [this](https://github.com/neovim/neovim/blob/cd8e15e3373dc9544d582640f043d3dee83a953d/runtime/lua/vim/treesitter/languagetree.lua#L351) call to [included_regions](https://github.com/neovim/neovim/blob/cd8e15e3373dc9544d582640f043d3dee83a953d/runtime/lua/vim/treesitter/languagetree.lua#L649) is crucial, it will return an empty range, thus parse the entire buffer.

with this change, [included_regions](https://github.com/neovim/neovim/blob/cd8e15e3373dc9544d582640f043d3dee83a953d/runtime/lua/vim/treesitter/languagetree.lua#L649) no longer return empty range, thus result in faster highlight.

related: https://github.com/MagicDuck/grug-far.nvim/issues/286