### PR TITLE
Make the base LSP label more like others

### DIFF
--- a/lua/trouble/sources/lsp.lua
+++ b/lua/trouble/sources/lsp.lua
@@ -77,7 +77,7 @@ M.config = {
         { "filename", format = "{file_icon} {filename} {count}" },
       },
       sort = { "filename", "pos", "text" },
-      format = "{text:ts} ({item.client}) {pos}",
+      format = "{text:ts} {pos} {hl:Title}{item.client:Title}{hl}",
     },
     lsp = {
       desc = "LSP definitions, references, implementations, type definitions, and declarations",


### PR DESCRIPTION
## Description

The base entry has an label with the LSP client name in
parentheses, which pushes the range to the right, making
it more likely that the range will leave the edge of the viewport.

Since the range is more useful information than the LSP client,
change the base label format to be more like the others.

This also improves the appearance of the tree.

e.g.

```
     └╴1 ACCOUNT-ENTRY-VIEW VIEW OF ACCOUNT-ENTRY (natls) [105, 3]

     becomes                                  highlighted  v---v

     └╴1 ACCOUNT-ENTRY-VIEW VIEW OF ACCOUNT-ENTRY [105, 3] natls
```
