### PR TITLE
fix(Readme): Fixing command for starting Trouble

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install the plugin with your preferred package manager:
 {
   "folke/trouble.nvim",
   opts = {}, -- for default options, refer to the configuration section for custom setup.
-  cmd = "Trouble",
+  cmd = { "Trouble" },
   keys = {
     {
       "<leader>xx",


### PR DESCRIPTION
# Fixed bug of "Trouble" not being an editor command

When using `cmd = { "Trouble" }`, Lazy.nvim properly registers the command before executing key mappings. If you use `cmd = "Trouble"`, Lazy.nvim treats it as a string and might not register it correctly for delayed loading. The correct format ensures **Trouble.nvim is loaded before commands are executed**, preventing the `E492: Not an editor command` error.

## Description

This pull request fixes an issue where **Trouble.nvim** was not recognized as a valid command when using Lazy.nvim. The problem occurred because the command was defined as a string (`cmd = "Trouble"`) instead of an array (`cmd = { "Trouble" }`). Lazy.nvim requires a table format for multiple commands to ensure proper registration.

### Changes:
- Updated **Lazy.nvim configuration** to use `{ "Trouble" }` instead of `"Trouble"`.
- Ensured that **Trouble.nvim loads before key mappings are executed**.
- Prevents `E492: Not an editor command` when running `:Trouble`.

### Steps to Reproduce the Bug
1. Set up **Trouble.nvim** with Lazy.nvim using `cmd = "Trouble"`.
2. Restart Neovim and try running:
   ```vim
   :Trouble diagnostics toggle
3. Observe the E492: Not an editor command error.

 ### Steps to Verify the Fix
Update the Lazy.nvim plugin definition to use:
```lua
cmd = { "Trouble" }
```
Restart Neovim and run:
```vim
:Trouble diagnostics toggle
```
Confirm that Trouble.nvim loads correctly and the command works as expected.