### PR TITLE
fix(float): respect latest option `vim.o.winborder`

### DIFF
--- a/lua/trouble/view/treesitter.lua
+++ b/lua/trouble/view/treesitter.lua
@@ -8,14 +8,14 @@ local ns = vim.api.nvim_create_namespace("trouble.treesitter")
 local TSHighlighter = vim.treesitter.highlighter
 
 local function wrap(name)
-  return function(_, win, buf, ...)
+  return function(win, buf, ...)
     if not M.cache[buf] then
       return false
     end
     for _, hl in pairs(M.cache[buf] or {}) do
       if hl.enabled then
         TSHighlighter.active[buf] = hl.highlighter
-        TSHighlighter[name](_, win, buf, ...)
+        TSHighlighter[name](win, buf, ...)
       end
     end
     TSHighlighter.active[buf] = nil

--- a/lua/trouble/view/window.lua
+++ b/lua/trouble/view/window.lua
@@ -311,6 +311,7 @@ function M:mount_float(opts)
   config.focusable = true
   config.height = opts.size.height <= 1 and math.floor(parent_size.height * opts.size.height) or opts.size.height
   config.width = opts.size.width <= 1 and math.floor(parent_size.width * opts.size.width) or opts.size.width
+  config.border = opts.border or "none"
 
   config.row = math.abs(opts.position[1]) <= 1 and math.floor((parent_size.height - config.height) * opts.position[1])
     or opts.position[1]


### PR DESCRIPTION
## Description

Setting the latest neovim option `vim.o.winborder` causes `vim.api.nvim_open_win` to copy the option if the border is not defined.

## Screenshots

before:
![image](https://github.com/user-attachments/assets/fe90701b-f0e9-43be-8403-673f5ff9d08a)

after:
![image](https://github.com/user-attachments/assets/8adbc457-4507-4e96-8e15-8a4a863504bf)