### PR TITLE
Proposal: prefer fold icons to indent

### DIFF
--- a/lua/trouble/view/render.lua
+++ b/lua/trouble/view/render.lua
@@ -150,7 +150,7 @@ function M:node(node, section, indent, is_last)
   if node.item then
     ---@type trouble.Indent.type
     local symbol = self:is_folded(node) and "fold_closed"
-      or node:depth() == 1 and "fold_open"
+      or not node:is_leaf() and "fold_open"
       or is_last and "last"
       or "middle"
     symbol = node:depth() == 1 and node:is_leaf() and "ws" or symbol


### PR DESCRIPTION
This is a proposal to prefer fold icons to indent icons instead of the other way around when both are displayed. Not final and should be also made configurable to also enable current behavior.

It is a simple change in one `if` condition.

In my case it would make it possible to achieve a clean look without indent guides and with fold icons in front of all foldable nodes.

Before:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/43409a9a-ff83-4802-b670-70ba57fa4328" />

After:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/cf174132-679f-4529-9203-3a05a5f7f9c6" />