### PR TITLE
fix(snacks): forward cwd to snacks picker items

### DIFF
--- a/lua/trouble/item.lua
+++ b/lua/trouble/item.lua
@@ -17,6 +17,7 @@ local Util = require("trouble.util")
 ---@field source string
 ---@field cache table<string,any>
 ---@field range? trouble.Range
+---@field cwd? string
 local M = {}
 
 ---@param opts trouble.Item | {filename?:string}
@@ -36,7 +37,8 @@ function M.new(opts)
   end
   assert(self.filename, "filename is required")
   if self.filename then
-    self.filename = vim.fs.normalize(self.filename)
+    local path = self.cwd and vim.fs.joinpath(self.cwd, self.filename) or self.filename
+    self.filename = vim.fs.normalize(path)
     local parts = vim.split(self.filename, "/", { plain = true })
     self.basename = table.remove(parts)
     self.dirname = table.concat(parts, "/")

--- a/lua/trouble/item.lua
+++ b/lua/trouble/item.lua
@@ -37,8 +37,8 @@ function M.new(opts)
   end
   assert(self.filename, "filename is required")
   if self.filename then
-    local path = self.cwd and vim.fs.joinpath(self.cwd, self.filename) or self.filename
-    self.filename = vim.fs.normalize(path)
+    local normalized = vim.fs.normalize(self.filename)
+    self.filename = self.cwd and vim.fs.joinpath(vim.fs.normalize(self.cwd), normalized) or normalized
     local parts = vim.split(self.filename, "/", { plain = true })
     self.basename = table.remove(parts)
     self.dirname = table.concat(parts, "/")

--- a/lua/trouble/item.lua
+++ b/lua/trouble/item.lua
@@ -37,8 +37,10 @@ function M.new(opts)
   end
   assert(self.filename, "filename is required")
   if self.filename then
-    local normalized = vim.fs.normalize(self.filename)
-    self.filename = self.cwd and vim.fs.joinpath(vim.fs.normalize(self.cwd), normalized) or normalized
+    self.filename = vim.fs.normalize(self.filename)
+    if self.cwd then
+      self.cwd = vim.fs.normalize(self.cwd)
+    end
     local parts = vim.split(self.filename, "/", { plain = true })
     self.basename = table.remove(parts)
     self.dirname = table.concat(parts, "/")
@@ -68,6 +70,14 @@ function M.add_id(items, fields)
   end
 end
 
+---@return string
+function M:get_full_path()
+  if self.cwd then
+    return vim.fs.joinpath(self.cwd, self.filename)
+  end
+  return self.filename
+end
+
 ---@return string?
 function M:get_ft(buf)
   if self.buf and vim.api.nvim_buf_is_loaded(self.buf) then
@@ -76,12 +86,13 @@ function M:get_ft(buf)
   if not self.filename then
     return
   end
-  local ft = Cache.ft[self.filename]
+  local full_path = self:get_full_path()
+  local ft = Cache.ft[full_path]
   if ft == nil then
     -- HACK: make sure we always pass a valid buf,
     -- otherwise some detectors will fail hard (like ts)
-    ft = vim.filetype.match({ filename = self.filename, buf = buf or 0 })
-    Cache.ft[self.filename] = ft or false -- cache misses too
+    ft = vim.filetype.match({ filename = full_path, buf = buf or 0 })
+    Cache.ft[full_path] = ft or false -- cache misses too
   end
   return ft
 end
@@ -138,10 +149,11 @@ function M.add_text(items, opts)
   for _, item in ipairs(items) do
     if not item.item.text and item.filename then
       -- schedule to get the lines
-      todo[item.filename] = todo[item.filename] or { rows = {} }
-      todo[item.filename].buf = todo[item.filename].buf or item.buf
+      local full_path = item:get_full_path()
+      todo[full_path] = todo[full_path] or { rows = {} }
+      todo[full_path].buf = todo[full_path].buf or item.buf
       for r = item.pos[1], item.end_pos and item.end_pos[1] or item.pos[1] do
-        table.insert(todo[item.filename].rows, r)
+        table.insert(todo[full_path].rows, r)
         if not opts.multiline then
           break
         end
@@ -160,9 +172,10 @@ function M.add_text(items, opts)
   end
   for _, item in ipairs(items) do
     if not item.item.text and item.filename then
+      local full_path = item:get_full_path()
       local lines = {} ---@type string[]
       for row = item.pos[1], item.end_pos[1] do
-        local line = buf_lines[item.filename][row] or ""
+        local line = buf_lines[full_path][row] or ""
         if row == item.pos[1] and row == item.end_pos[1] then
           if opts.mode == "after" then
             line = line:sub(item.pos[2] + 1)

--- a/lua/trouble/sources/snacks.lua
+++ b/lua/trouble/sources/snacks.lua
@@ -38,7 +38,8 @@ function M.item(item)
   return Item.new({
     source = "snacks",
     buf = item.buf,
-    filename = item.cwd and vim.fs.joinpath(item.cwd, item.file) or item.file,
+    cwd = item.cwd,
+    filename = item.file,
     pos = item.pos,
     end_pos = item.end_pos,
     text = item.line or item.comment or item.label or item.name or item.detail or false,

--- a/lua/trouble/sources/snacks.lua
+++ b/lua/trouble/sources/snacks.lua
@@ -38,7 +38,7 @@ function M.item(item)
   return Item.new({
     source = "snacks",
     buf = item.buf,
-    filename = vim.fs.joinpath(item.cwd, item.file),
+    filename = item.cwd and vim.fs.joinpath(item.cwd, item.file) or item.file,
     pos = item.pos,
     end_pos = item.end_pos,
     text = item.line or item.comment or item.label or item.name or item.detail or false,

--- a/lua/trouble/sources/snacks.lua
+++ b/lua/trouble/sources/snacks.lua
@@ -38,7 +38,7 @@ function M.item(item)
   return Item.new({
     source = "snacks",
     buf = item.buf,
-    filename = item.file,
+    filename = vim.fs.joinpath(item.cwd, item.file),
     pos = item.pos,
     end_pos = item.end_pos,
     text = item.line or item.comment or item.label or item.name or item.detail or false,

--- a/lua/trouble/view/init.lua
+++ b/lua/trouble/view/init.lua
@@ -253,7 +253,7 @@ function M:jump(item, opts)
     return
   end
 
-  item.buf = item.buf or vim.fn.bufadd(item.filename)
+  item.buf = item.buf or vim.fn.bufadd(item:get_full_path())
 
   if not vim.api.nvim_buf_is_loaded(item.buf) then
     vim.fn.bufload(item.buf)

--- a/lua/trouble/view/preview.lua
+++ b/lua/trouble/view/preview.lua
@@ -36,9 +36,10 @@ end
 function M.create(item, opts)
   opts = opts or {}
 
-  local buf = item.buf or vim.fn.bufnr(item.filename)
+  local full_path = item:get_full_path()
+  local buf = item.buf or vim.fn.bufnr(full_path)
 
-  if item.filename and vim.fn.isdirectory(item.filename) == 1 then
+  if item.filename and vim.fn.isdirectory(full_path) == 1 then
     return
   end
 
@@ -48,7 +49,7 @@ function M.create(item, opts)
       buf = vim.api.nvim_create_buf(false, true)
       vim.bo[buf].bufhidden = "wipe"
       vim.bo[buf].buftype = "nofile"
-      local lines = Util.get_lines({ path = item.filename, buf = item.buf })
+      local lines = Util.get_lines({ path = full_path, buf = item.buf })
       if not lines then
         return
       end
@@ -61,7 +62,7 @@ function M.create(item, opts)
         end
       end
     else
-      item.buf = vim.fn.bufadd(item.filename)
+      item.buf = vim.fn.bufadd(full_path)
       buf = item.buf
 
       if not vim.api.nvim_buf_is_loaded(item.buf) then


### PR DESCRIPTION
## Description

Fixes an issue where `trouble_open` didn’t respect the `cwd` in the Snacks Picker integration.

Right now, if you use something like:
```lua
Snacks.picker.files({ cwd = other_cwd })
```
You’ll see the right results, but navigation breaks unless you're in the same root directory. This is especially annoying when working in a monorepo and searching inside a specific package.

## Related Issue(s)

  - Fixes #629


