### PR TITLE
fix(view): adapt to the changes for "nvim_set_decoration_provider"

### DIFF
--- a/lua/trouble/view/treesitter.lua
+++ b/lua/trouble/view/treesitter.lua
@@ -29,10 +29,18 @@ function M.setup()
   end
   M.did_setup = true
 
-  vim.api.nvim_set_decoration_provider(ns, {
-    on_win = wrap("_on_win"),
-    on_line = wrap("_on_line"),
-  })
+  -- https://github.com/neovim/neovim/commit/5edbabdbec0ac3fba33be8afc008845130158583
+  if vim.fn.has("nvim-0.12.0") == 1 then
+    vim.api.nvim_set_decoration_provider(ns, {
+      on_win = wrap("_on_win"),
+      on_range = wrap("_on_range"),
+    })
+  else
+    vim.api.nvim_set_decoration_provider(ns, {
+      on_win = wrap("_on_win"),
+      on_line = wrap("_on_line"),
+    })
+  end
 
   vim.api.nvim_create_autocmd("BufWipeout", {
     group = vim.api.nvim_create_augroup("trouble.treesitter.hl", { clear = true }),


### PR DESCRIPTION
## Description

A recent commit in Neovim (5edbabdbec0) changed the decoration provider API (vim.api.nvim_set_decoration_provider), replacing the on_line callback with on_range.

This breaking change, which also alters the callback arguments, causes an error when using trouble.nvim with recent Neovim nightly builds. This commit updates the call in lua/trouble/view/treesitter.lua to use the new on_range API, restoring compatibility.

 - Relevant Neovim Commit: https://github.com/neovim/neovim/commit/5edbabdbec0ac3fba33be8afc008845130158583
 - Relevant Neovim PR: https://github.com/neovim/neovim/pull/31400

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

https://github.com/folke/trouble.nvim/issues/655