### PR TITLE
fix(float): respect latest option `vim.o.winborder`

### DIFF
--- a/lua/trouble/view/window.lua
+++ b/lua/trouble/view/window.lua
@@ -311,6 +311,7 @@ function M:mount_float(opts)
   config.focusable = true
   config.height = opts.size.height <= 1 and math.floor(parent_size.height * opts.size.height) or opts.size.height
   config.width = opts.size.width <= 1 and math.floor(parent_size.width * opts.size.width) or opts.size.width
+  config.border = opts.border or "none"
 
   config.row = math.abs(opts.position[1]) <= 1 and math.floor((parent_size.height - config.height) * opts.position[1])
     or opts.position[1]


### PR DESCRIPTION
#633, cherry picked from commit 6d7c4a5335975a5a7047a35283faa3fa30ab58da

## Description

Setting the latest neovim option `vim.o.winborder` causes `vim.api.nvim_open_win` to copy the option if the border is not defined.

## Screenshots

before:
![image](https://github.com/user-attachments/assets/fe90701b-f0e9-43be-8403-673f5ff9d08a)

after:
![image](https://github.com/user-attachments/assets/8adbc457-4507-4e96-8e15-8a4a863504bf)